### PR TITLE
WR-87 feat(notifications): add notifications skeleton page

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -54,6 +54,9 @@ const config = {
         DashboardRosterScreen: "roster",
       },
     },
+    Notifications: {
+      path: "notifications",
+    },
   },
 }
 

--- a/app/i18n/en.ts
+++ b/app/i18n/en.ts
@@ -34,6 +34,9 @@ const en = {
     tapToLogIn: "Tap to log in!",
     hint: "Hint: you can use any email address and your favorite password :)",
   },
+  notificationScreen: {
+    title: "Notifications",
+  },
   dashboardNavigator: {
     homeTab: "Home",
     teamsTab: "Teams",

--- a/app/navigators/AppNavigator.tsx
+++ b/app/navigators/AppNavigator.tsx
@@ -12,6 +12,7 @@ import Config from "@/config"
 import { useAuth } from "@/context/AuthContext"
 import { ErrorBoundary } from "@/screens/ErrorScreen/ErrorBoundary"
 import { LoginScreen } from "@/screens/LoginScreen"
+import { NotificationsScreen } from "@/screens/NotificationsScreen"
 import { useAppTheme } from "@/theme/context"
 
 import { DashboardNavigator, DashboardTabParamList } from "./DashboardNavigator"
@@ -29,6 +30,7 @@ import { navigationRef, useBackButtonHandler } from "./navigationUtilities"
 export type AppStackParamList = {
   Login: undefined
   Dashboard: NavigatorScreenParams<DashboardTabParamList>
+  Notifications: undefined
   // 🔥 Your screens go here
   // IGNITE_GENERATOR_ANCHOR_APP_STACK_PARAM_LIST
 }
@@ -76,6 +78,14 @@ const AppStack = () => {
       )}
 
       {/** 🔥 Your screens go here */}
+      <Stack.Screen
+        name="Notifications"
+        component={NotificationsScreen}
+        options={{
+          presentation: "fullScreenModal",
+          animation: "fade",
+        }}
+      />
       {/* IGNITE_GENERATOR_ANCHOR_APP_STACK_SCREENS */}
     </Stack.Navigator>
   )

--- a/app/screens/DashboardHomeScreen.tsx
+++ b/app/screens/DashboardHomeScreen.tsx
@@ -1,10 +1,15 @@
 import { FC, ReactElement } from "react"
+import { Pressable } from "react-native"
+import { View } from "react-native"
 
+import { Icon } from "@/components/Icon"
 import { Screen } from "@/components/Screen"
 import { Text } from "@/components/Text"
 import { TxKeyPath } from "@/i18n"
 import { DashboardTabScreenProps } from "@/navigators/DashboardNavigator"
+import { useAppTheme } from "@/theme/context"
 import { $styles } from "@/theme/styles"
+import { $topRightIcons, $headerIcons } from "@/theme/styles"
 import type { Theme } from "@/theme/types"
 
 export interface Dashboard {
@@ -15,8 +20,19 @@ export interface Dashboard {
 
 export const DashboardHomeScreen: FC<DashboardTabScreenProps<"DashboardHome">> =
   function DashboardHomeScreen(_props) {
+    const { navigation } = _props
+    const { themed } = useAppTheme()
+
     return (
       <Screen preset="scroll" contentContainerStyle={$styles.container} safeAreaEdges={["top"]}>
+        <View style={themed($topRightIcons)}>
+          <Pressable
+            onPress={() => navigation.navigate("Notifications")}
+            style={themed($headerIcons)}
+          >
+            <Icon icon="components" />
+          </Pressable>
+        </View>
         <Text preset="heading" tx="dashboardHomeScreen:jumpStart" />
       </Screen>
     )

--- a/app/screens/NotificationsScreen.tsx
+++ b/app/screens/NotificationsScreen.tsx
@@ -1,0 +1,31 @@
+import { FC } from "react"
+import { Pressable } from "react-native"
+import { View } from "react-native"
+
+import { Icon } from "@/components/Icon"
+import { Screen } from "@/components/Screen"
+import { Text } from "@/components/Text"
+import type { AppStackScreenProps } from "@/navigators/AppNavigator"
+import { useAppTheme } from "@/theme/context"
+import { $topRightIcons, $headerIcons } from "@/theme/styles"
+import { $styles } from "@/theme/styles"
+
+interface NotificationsScreenProps extends AppStackScreenProps<"Notifications"> {}
+
+export const NotificationsScreen: FC<NotificationsScreenProps> = function NotificationsScreen(
+  _props,
+) {
+  const { navigation } = _props
+  const { themed } = useAppTheme()
+
+  return (
+    <Screen preset="scroll" contentContainerStyle={$styles.container} safeAreaEdges={["top"]}>
+      <View style={themed($topRightIcons)}>
+        <Pressable onPress={() => navigation.goBack()} style={themed($headerIcons)}>
+          <Icon icon="components" />
+        </Pressable>
+      </View>
+      <Text preset="heading" tx="notificationScreen:title" />
+    </Screen>
+  )
+}

--- a/app/theme/styles.ts
+++ b/app/theme/styles.ts
@@ -1,6 +1,8 @@
 import { ViewStyle } from "react-native"
+import { TextStyle } from "react-native"
 
 import { spacing } from "./spacing"
+import type { ThemedStyle } from "./types"
 
 /* Use this file to define styles that are used in multiple places in your app. */
 export const $styles = {
@@ -21,3 +23,17 @@ export const $styles = {
     overflow: "hidden",
   } as ViewStyle,
 }
+
+export const $topRightIcons: ThemedStyle<TextStyle> = () => ({
+  position: "absolute",
+  top: 16,
+  right: 16,
+  flexDirection: "row",
+  alignItems: "center",
+  zIndex: 1,
+})
+
+// Currently this is just padding
+export const $headerIcons: ThemedStyle<TextStyle> = () => ({
+  marginRight: spacing.md,
+})


### PR DESCRIPTION
Added the bare skeleton for the notifications page with filler icons for now

https://github.com/user-attachments/assets/351c82a0-dae4-4818-b213-da3665bc3e4f

Unfortunately for the `Stack.Screen` parameter there isn't a `slide_from_top` for the `animation` prop so it's currently a fade which deviates slightly from the Figma. 
`presentation: "fullScreenModal"` is added as it makes the modal transition (and hence the fade) faster.

Hardcoded absolute values for `top` and `right` are added as placeholders for now, they are likely to change since they're probably going to sit in another `header` component for our dashboard home screen.
