### PR TITLE
WR-90 feat: :wrench: Add border-radius tokens to tamagui config file

### DIFF
--- a/app/tamagui.config.ts
+++ b/app/tamagui.config.ts
@@ -1,7 +1,6 @@
 import { defaultConfig } from "@tamagui/config/v4"
 import { createTokens, createTamagui } from "tamagui"
 
-// Colour tokens
 const tokens = createTokens({
   ...defaultConfig.tokens,
   color: {
@@ -87,6 +86,20 @@ const tokens = createTokens({
     white700: "#E8E9E9",
     white800: "#E4E5E5",
     white900: "#E0E1E1",
+  },
+  radius: {
+    ...defaultConfig.tokens.radius,
+    1: 4,
+    2: 6,
+    3: 8,
+    4: 12,
+    5: 16,
+    6: 20,
+    7: 24,
+    8: 32,
+    9: 40,
+    10: 48,
+    full: 9999,
   },
 })
 


### PR DESCRIPTION
Define radius tokens for borders:
<img width="305" height="279" alt="Screenshot 2025-09-06 at 4 35 33 pm" src="https://github.com/user-attachments/assets/0d3c8671-9b6d-4f72-b4c8-120061ea9a74" />
So you can adjust like this:
<img width="348" height="60" alt="Screenshot 2025-09-06 at 4 36 21 pm" src="https://github.com/user-attachments/assets/f73bb45a-08ff-40a7-9614-8fae418f2ff3" />
<img width="375" height="92" alt="Screenshot 2025-09-06 at 4 36 29 pm" src="https://github.com/user-attachments/assets/b6846878-a014-44ff-92b9-89653616694c" />
And then: 
<img width="345" height="61" alt="Screenshot 2025-09-06 at 4 36 47 pm" src="https://github.com/user-attachments/assets/965e710c-5080-4540-a65f-fbde7c63ad40" />
<img width="373" height="94" alt="Screenshot 2025-09-06 at 4 36 55 pm" src="https://github.com/user-attachments/assets/f6090ed3-f238-4820-929f-2415369793e3" />
