### PR TITLE
WR-92 fix(general): fit commitlint precommit

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
 npm test
 npx lint-staged
-npx --no-install commitlint --edit "$1"


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-92)_

Our commitlint pre-commit was hanging onto stale, leftover commit messages because it was running during the pre-commit phase.

Having this check separately in `commit-msg` means that its triggered only when a commit message is created, so it only checks the most recent commit message. The `pre-commit` hook should only be running code checks so it's my bad that it was in there in the first place







---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
