### PR TITLE
WR-111 ci(general): enforce rebasing prior to merging into main

### DIFF
--- a/.github/workflows/enforce-rebase.yml
+++ b/.github/workflows/enforce-rebase.yml
@@ -1,6 +1,12 @@
 name: Enforce Rebase
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_sha:
+        description: "SHA of the pull request head commit"
+        required: true
+        type: string
   pull_request:
     branches: [main]
 
@@ -30,6 +36,42 @@ jobs:
           else
             echo "status=success" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set PR status to failure
+        if: github.event_name == 'workflow_dispatch' && steps.rebase_check.outputs.status == 'failure'
+        uses: actions/github-script@v6
+        env:
+          PR_SHA: ${{ github.event.inputs.pr_sha }}
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.PR_SHA,
+              state: 'failure',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions`,
+              description: 'Branch is not rebased on latest main.',
+              context: 'Automated Rebase Check'
+            });
+
+      - name: Set PR status to success
+        if: github.event_name == 'workflow_dispatch' && steps.rebase_check.outputs.status == 'success'
+        uses: actions/github-script@v6
+        env:
+          PR_SHA: ${{ github.event.inputs.pr_sha }}
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.PR_SHA,
+              state: 'success',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions`,
+              description: 'Branch is rebased on latest main.',
+              context: 'Automated Rebase Check'
+            });
 
       - name: Fail job if rebase check failed
         if: github.event_name == 'pull_request' && steps.rebase_check.outputs.status == 'failure'

--- a/.github/workflows/enforce-rebase.yml
+++ b/.github/workflows/enforce-rebase.yml
@@ -1,0 +1,36 @@
+name: Enforce Rebase
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-rebase:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Check merge base
+        id: rebase_check
+        run: |
+          git fetch origin main
+          MERGE_BASE=$(git merge-base HEAD origin/main)
+          LATEST_MAIN=$(git rev-parse origin/main)
+          echo "MERGE_BASE: $MERGE_BASE"
+          echo "LATEST_MAIN: $LATEST_MAIN"
+
+          # Ensure PR branch is directly on top of main
+          if [ "$MERGE_BASE" != "$LATEST_MAIN" ]; then
+            echo "Branch is not rebased on latest main. Run git fetch, git rebase origin/main and then resolve any/all merge conflicts with the Merge Editor. Continue the rebase with git rebase --continue until your rebase has completed successfully. Finish with git push --force to rebase."
+            echo "status=failure" >> $GITHUB_OUTPUT
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fail job if rebase check failed
+        if: github.event_name == 'pull_request' && steps.rebase_check.outputs.status == 'failure'
+        run: exit 1

--- a/.github/workflows/trigger-rebase-check
+++ b/.github/workflows/trigger-rebase-check
@@ -1,0 +1,45 @@
+name: Trigger Rebase Check On Open PRs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger rebase check on open PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: 'main'
+            });
+
+            for (const pr of prs.data) {
+              // Set commit status to pending before dispatching workflow
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: pr.head.sha,
+                state: 'pending',
+                target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions`,
+                description: 'Rebase check in progress',
+                context: 'Automated Rebase Check'
+              });
+
+              // Dispatch the enforce-rebase workflow
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'enforce-rebase.yml',
+                ref: pr.head.ref,
+                  inputs: {
+                  pr_sha: pr.head.sha
+                  }
+              });
+            }


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-111)_

CI check to ensure that a branch is directly on top of main (rebased) before allowing merges.

The first commit adds a CI check which runs each time you push to a PR, ensuring that a PR has been rebased on the latest version of main

When CI is run at a certain point in time and all is green, if someone pushes to main, updating it, the CI check remains green. This creates an inconsistency between the (outdated) check saying that a PR has been rebased onto the latest version of main when it really hasn't been. To fix this:

The second commit adds another workflow which runs each time someone pushes to main. This re-triggers the rebase check on open PRs, marking them as stale (no longer on the latest version of main).

Couple things to note here:
1. Technically each time someone pushes to main, each PR by definition is automatically no longer rebased, so we could just put in a dummy commit check update which marks each PR as failing the check instead of actually running it. I figured this would be hard to follow from someone (1) reading the repo (2) failing the check and not knowing why, so I've opted to actually run the workflow 
2. Similarly, if we know that the workflow is going to fail that check each time main is pushed to, the step "Set PR status to success" is actually redundant and will never run – the check disappears each time someone pushes to their PR so if they were to rebase, the first commit's CI check would pass and the second commit's CI check woudn't run (only runs on changes to main). Again I've included it for completeness and readability, it can be removed if needed but poses no harm. 







---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
