### PR TITLE
WR-106 feat(general): create top nav bar component

### DIFF
--- a/app/components/BackHeader.tsx
+++ b/app/components/BackHeader.tsx
@@ -1,0 +1,37 @@
+import { Pressable } from "react-native"
+import { NativeStackNavigationProp } from "@react-navigation/native-stack"
+import { useTheme, XStack, Text, H6 } from "tamagui"
+
+import { BaseTopBar } from "./BaseTopBar"
+import { Icon } from "./Icon"
+
+interface BackHeaderProps {
+  navigation: NativeStackNavigationProp<any, any>
+  title: string
+  onSavePress?: () => void
+}
+
+const BackHeader = ({ navigation, title, onSavePress }: BackHeaderProps) => {
+  const theme = useTheme()
+
+  return (
+    <BaseTopBar>
+      <XStack alignItems="center" gap="$4">
+        <Pressable onPress={() => navigation.goBack()}>
+          <Icon color={theme.white100.val} icon="left" />
+        </Pressable>
+        <H6 color={theme.white100.val}>{title}</H6>
+      </XStack>
+
+      {onSavePress && (
+        <Pressable onPress={onSavePress}>
+          <Text color={theme.white100.val} mx="$4">
+            Save
+          </Text>
+        </Pressable>
+      )}
+    </BaseTopBar>
+  )
+}
+
+export { BackHeader }

--- a/app/components/BaseTopBar.tsx
+++ b/app/components/BaseTopBar.tsx
@@ -1,0 +1,28 @@
+import { XStack } from "tamagui"
+
+interface BaseTopBarProps {
+  children?: React.ReactNode
+}
+
+const BaseTopBar = ({ children }: BaseTopBarProps) => {
+  return (
+    <XStack
+      position="absolute"
+      top={0}
+      backgroundColor="$color.primary500"
+      width="100%"
+      height={56}
+      borderBottomLeftRadius={"$radius.4"}
+      borderBottomRightRadius={"$radius.4"}
+      boxShadow={"0px 5px 10px rgba(0, 0, 0, 0.5)"}
+      padding={10}
+      zIndex={1}
+      alignItems="center"
+      justifyContent="space-between"
+    >
+      {children}
+    </XStack>
+  )
+}
+
+export { BaseTopBar }

--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,29 +1,17 @@
 import { FC } from "react"
-import { Pressable } from "react-native"
-import { View } from "react-native"
 
-import { Icon } from "@/components/Icon"
+import { BackHeader } from "@/components/BackHeader"
 import { Screen } from "@/components/Screen"
-import { Text } from "@/components/Text"
 import type { AppStackScreenProps } from "@/navigators/AppNavigator"
-import { useAppTheme } from "@/theme/context"
-import { $topRightIcons, $headerIcons } from "@/theme/styles"
-import { $styles } from "@/theme/styles"
 
 interface ProfileScreenProps extends AppStackScreenProps<"ProfileScreen"> {}
 
 export const ProfileScreen: FC<ProfileScreenProps> = function ProfileScreen(_props) {
   const { navigation } = _props
-  const { themed } = useAppTheme()
 
   return (
-    <Screen preset="scroll" contentContainerStyle={$styles.container} safeAreaEdges={["top"]}>
-      <View style={themed($topRightIcons)}>
-        <Pressable onPress={() => navigation.goBack()} style={themed($headerIcons)}>
-          <Icon icon="anchor" />
-        </Pressable>
-      </View>
-      <Text preset="heading" tx="profileScreen:title" />
+    <Screen preset="scroll" safeAreaEdges={["top"]}>
+      <BackHeader navigation={navigation} title="Profile" />
     </Screen>
   )
 }


### PR DESCRIPTION
Made some generic components

BaseTopBar:
- contains general layout/color styles
- drop shadow, absolute position top
- takes children prop

BackHeader: 
- on top of the BaseTopBar
- back button that navigates back
- optionally takes a `onSavePress` function if the function is a settings page (to save profile or settings etc.) and conditionally displays the Save Button

Applied it to the profile screen for now, didnt want to cause immense merge conflicts so hoping to merge this in and then let team members working on specific views to apply it themselves

# Without Save 

<img width="881" height="335" alt="image" src="https://github.com/user-attachments/assets/3c9cb416-de1b-44dd-865d-2131066be9ba" />


# Nav demo (Save button does nothing for now) + with save param passed

https://github.com/user-attachments/assets/ea774079-5f67-4d31-9709-80dfb50d1e06



---

<details open><summary><strong>Checklist</strong></summary>

- [ ] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
