### PR TITLE
WR-109 feat(general): ✨ Create status lozenge component

### DIFF
--- a/app/components/Lozenge.tsx
+++ b/app/components/Lozenge.tsx
@@ -1,0 +1,5 @@
+import { Button } from "tamagui"
+
+export const Lozenge = () => {
+  return <Button borderRadius="$radius.full">Hi</Button>
+}

--- a/app/components/Lozenge.tsx
+++ b/app/components/Lozenge.tsx
@@ -1,5 +1,112 @@
-import { Button } from "tamagui"
+import { useState } from "react"
+import { Button, Text, useTheme } from "tamagui"
 
-export const Lozenge = () => {
-  return <Button borderRadius="$radius.full">Hi</Button>
+import { Icon, IconTypes } from "./Icon"
+
+interface LozengeProps {
+  type:
+    | "leave"
+    | "swap"
+    | "event"
+    | "available"
+    | "requested"
+    | "urgent"
+    | "approved"
+    | "awaiting"
+    | "declined"
+    | "assigned"
+    | "openShift"
+  active?: boolean
+  onPress?: () => void
+}
+
+const LOZENGE_TEXT_MAP: Record<string, string> = {
+  leave: "Leave",
+  swap: "Swap",
+  event: "Event",
+  available: "Available",
+  requested: "Requested",
+  urgent: "Urgent",
+  approved: "Approved",
+  awaiting: "Awaiting",
+  declined: "Declined",
+  assigned: "Assigned",
+  openShift: "OpenShift",
+}
+
+const LOZENGE_ICON_MAP: Record<string, IconTypes> = {
+  leave: "leave",
+  swap: "swap",
+  event: "openShift",
+  urgent: "zap",
+  openShift: "openShift",
+}
+
+const LOZENGE_BGCOLOR_MAP: Record<string, string> = {
+  leave: "mono100",
+  swap: "mono100",
+  event: "mono100",
+  available: "green500",
+  requested: "mono100",
+  urgent: "red500",
+  approved: "green500",
+  awaiting: "yellow400",
+  declined: "red500",
+  assigned: "secondary300",
+  openShift: "mono100",
+}
+
+const LOZENGE_SELECTED_BGCOLOR_MAP: Record<string, string> = {
+  leave: "secondary400",
+  swap: "yellow400",
+  openShift: "green500",
+  approved: "green500",
+  awaiting: "yellow400",
+  declined: "red500",
+}
+
+const LOZENGE_TEXT_COLOR_MAP: Record<string, string> = {
+  available: "green800",
+  urgent: "red800",
+  approved: "green800",
+  awaiting: "yellow800",
+  declined: "red800",
+  assigned: "accent800",
+}
+
+export const Lozenge = ({ type, active = false, onPress }: LozengeProps) => {
+  const theme = useTheme()
+  const [selected, setSelected] = useState(false)
+
+  const buttonText = LOZENGE_TEXT_MAP[type] || "Lozenge"
+  const buttonIcon = LOZENGE_ICON_MAP[type] || null
+
+  const defaultBg = !active ? theme[LOZENGE_BGCOLOR_MAP[type]]?.val : theme["mono100"]?.val
+  const selectedBg = theme[LOZENGE_SELECTED_BGCOLOR_MAP[type]]?.val || defaultBg
+  const buttonBgColor = selected ? selectedBg : defaultBg
+
+  const buttonTextColor = !active ? theme[LOZENGE_TEXT_COLOR_MAP[type]]?.val : theme["mono900"]?.val
+
+  return (
+    <Button
+      height={active ? 33 : 24}
+      borderRadius="$full"
+      size="$3"
+      width="auto"
+      flexGrow={0}
+      alignSelf="flex-start"
+      disabled={!active}
+      backgroundColor={buttonBgColor}
+      onPress={() => {
+        if (!active) return
+        setSelected(!selected)
+        onPress?.()
+      }}
+    >
+      {buttonIcon && <Icon icon={buttonIcon} size={16} color={buttonTextColor} />}
+      <Text fontSize={12} color={buttonTextColor}>
+        {buttonText}
+      </Text>
+    </Button>
+  )
 }

--- a/app/components/Lozenge.tsx
+++ b/app/components/Lozenge.tsx
@@ -38,7 +38,6 @@ const LOZENGE_ICON_MAP: Record<string, IconTypes> = {
   leave: "leave",
   swap: "swap",
   event: "openShift",
-  urgent: "zap",
   openShift: "openShift",
 }
 

--- a/app/components/Lozenge.tsx
+++ b/app/components/Lozenge.tsx
@@ -20,78 +20,104 @@ interface LozengeProps {
   onPress?: () => void
 }
 
-const LOZENGE_TEXT_MAP: Record<string, string> = {
-  leave: "Leave",
-  swap: "Swap",
-  event: "Event",
-  available: "Available",
-  requested: "Requested",
-  urgent: "Urgent",
-  approved: "Approved",
-  awaiting: "Awaiting",
-  declined: "Declined",
-  assigned: "Assigned",
-  openShift: "OpenShift",
+interface LozengeConfig {
+  text: string
+  icon?: IconTypes
+  bgColor: string
+  selectedBgColor?: string
+  textColor?: string
 }
 
-const LOZENGE_ICON_MAP: Record<string, IconTypes> = {
-  leave: "leave",
-  swap: "swap",
-  event: "openShift",
-  openShift: "openShift",
-}
-
-const LOZENGE_BGCOLOR_MAP: Record<string, string> = {
-  leave: "mono100",
-  swap: "mono100",
-  event: "mono100",
-  available: "green500",
-  requested: "mono100",
-  urgent: "red500",
-  approved: "green500",
-  awaiting: "yellow400",
-  declined: "red500",
-  assigned: "secondary300",
-  openShift: "mono100",
-}
-
-const LOZENGE_SELECTED_BGCOLOR_MAP: Record<string, string> = {
-  leave: "secondary400",
-  swap: "yellow400",
-  openShift: "green500",
-  approved: "green500",
-  awaiting: "yellow400",
-  declined: "red500",
-}
-
-const LOZENGE_TEXT_COLOR_MAP: Record<string, string> = {
-  available: "green800",
-  urgent: "red800",
-  approved: "green800",
-  awaiting: "yellow800",
-  declined: "red800",
-  assigned: "accent800",
+const LOZENGE_CONFIG: Record<LozengeProps["type"], LozengeConfig> = {
+  leave: {
+    text: "Leave",
+    icon: "leave",
+    bgColor: "mono100",
+    selectedBgColor: "secondary400",
+    textColor: "mono900",
+  },
+  swap: {
+    text: "Swap",
+    icon: "swap",
+    bgColor: "mono100",
+    selectedBgColor: "yellow400",
+    textColor: "mono900",
+  },
+  event: {
+    text: "Event",
+    icon: "openShift",
+    bgColor: "mono100",
+    textColor: "mono900",
+  },
+  available: {
+    text: "Available",
+    bgColor: "green500",
+    textColor: "green800",
+  },
+  requested: {
+    text: "Requested",
+    bgColor: "mono100",
+    textColor: "mono900",
+  },
+  urgent: {
+    text: "Urgent",
+    bgColor: "red500",
+    textColor: "red800",
+  },
+  approved: {
+    text: "Approved",
+    bgColor: "green500",
+    selectedBgColor: "green500",
+    textColor: "green800",
+  },
+  awaiting: {
+    text: "Awaiting",
+    bgColor: "yellow400",
+    selectedBgColor: "yellow400",
+    textColor: "yellow800",
+  },
+  declined: {
+    text: "Declined",
+    bgColor: "red500",
+    selectedBgColor: "red500",
+    textColor: "red800",
+  },
+  assigned: {
+    text: "Assigned",
+    bgColor: "secondary300",
+    textColor: "accent800",
+  },
+  openShift: {
+    text: "OpenShift",
+    icon: "openShift",
+    bgColor: "mono100",
+    selectedBgColor: "green500",
+    textColor: "mono900",
+  },
 }
 
 export const Lozenge = ({ type, active = false, onPress }: LozengeProps) => {
   const theme = useTheme()
   const [selected, setSelected] = useState(false)
 
-  const buttonText = LOZENGE_TEXT_MAP[type] || "Lozenge"
-  const buttonIcon = LOZENGE_ICON_MAP[type] || null
+  const lozenge = LOZENGE_CONFIG[type]
 
-  const defaultBg = !active ? theme[LOZENGE_BGCOLOR_MAP[type]]?.val : theme["mono100"]?.val
-  const selectedBg = theme[LOZENGE_SELECTED_BGCOLOR_MAP[type]]?.val || defaultBg
+  const buttonText = lozenge.text || "Lozenge"
+  const buttonIcon = lozenge.icon || null
+
+  const defaultBg = !active ? theme[lozenge.bgColor]?.val : theme["mono100"]?.val
+  const selectedBg = lozenge.selectedBgColor ? theme[lozenge.selectedBgColor]?.val : defaultBg
   const buttonBgColor = selected ? selectedBg : defaultBg
 
-  const buttonTextColor = !active ? theme[LOZENGE_TEXT_COLOR_MAP[type]]?.val : theme["mono900"]?.val
+  const buttonTextColor =
+    !active && lozenge.textColor ? theme[lozenge.textColor]?.val : theme["mono900"]?.val
 
   return (
     <Button
       height={active ? 33 : 24}
       borderRadius="$full"
       size="$3"
-      width="auto"
+      width={active ? 110 : "auto"}
       flexGrow={0}
       alignSelf="flex-start"
       disabled={!active}

--- a/app/screens/DashboardHomeScreen.tsx
+++ b/app/screens/DashboardHomeScreen.tsx
@@ -4,7 +4,6 @@ import { View } from "react-native"
 
 import { Button } from "@/components/Button"
 import { Icon } from "@/components/Icon"
-import { Lozenge } from "@/components/Lozenge"
 import { Screen } from "@/components/Screen"
 import { Text } from "@/components/Text"
 import { TxKeyPath } from "@/i18n"
@@ -44,7 +43,6 @@ export const DashboardHomeScreen: FC<DashboardTabScreenProps<"DashboardHome">> =
             </Pressable>
           </View>
           <Text preset="heading" tx="dashboardHomeScreen:jumpStart" />
-          <Lozenge />
         </Screen>
 
         {/* FAB positioned relative to the outer View */}

--- a/app/screens/DashboardHomeScreen.tsx
+++ b/app/screens/DashboardHomeScreen.tsx
@@ -4,6 +4,7 @@ import { View } from "react-native"
 
 import { Button } from "@/components/Button"
 import { Icon } from "@/components/Icon"
+import { Lozenge } from "@/components/Lozenge"
 import { Screen } from "@/components/Screen"
 import { Text } from "@/components/Text"
 import { TxKeyPath } from "@/i18n"
@@ -43,6 +44,7 @@ export const DashboardHomeScreen: FC<DashboardTabScreenProps<"DashboardHome">> =
             </Pressable>
           </View>
           <Text preset="heading" tx="dashboardHomeScreen:jumpStart" />
+          <Lozenge />
         </Screen>
 
         {/* FAB positioned relative to the outer View */}


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-109)_

### Changes:
- Created a `Lozenge` component that takes in the props: `type`, `active` and `onPress`
- `active` and `onPress` are optional to distinguish between the status lozenges and the filter lozenges.

iOS: 
<img width="359" height="426" alt="Screenshot 2025-09-13 at 3 42 51 pm" src="https://github.com/user-attachments/assets/89491d0f-fe32-4ddc-8543-6d3800fb49ef" />

<img width="348" height="260" alt="Screenshot 2025-09-13 at 3 41 06 pm" src="https://github.com/user-attachments/assets/3ab3da0b-aa2e-4393-b4fc-a1b65a2d937e" />

Android:
<img width="353" height="439" alt="Screenshot 2025-09-13 at 3 41 22 pm" src="https://github.com/user-attachments/assets/997d2621-b589-4c20-bf44-2f1bf80a9e10" />
<img width="349" height="268" alt="Screenshot 2025-09-13 at 3 41 32 pm" src="https://github.com/user-attachments/assets/07df971f-6466-4f59-971a-82e37f7aa957" />

Demo:
https://github.com/user-attachments/assets/f5a6aa87-fb7d-467c-987a-0c50a97eeec4


Demo code:
<img width="423" height="403" alt="Screenshot 2025-09-13 at 3 44 54 pm" src="https://github.com/user-attachments/assets/f7e76a5c-a287-4067-b6d0-8ea4ed96b47c" />



Follow-up ticket to update typographies: https://comp30022weroster2025s2.atlassian.net/browse/WR-113

---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
