### PR TITLE
WR-105 feat(team-roster): :sparkles: create team roster shift tab component

### DIFF
--- a/app/components/TeamRosterShiftTabBar.tsx
+++ b/app/components/TeamRosterShiftTabBar.tsx
@@ -1,0 +1,61 @@
+import { useTheme, XStack, Text } from "tamagui"
+
+import { Icon, IconTypes } from "./Icon"
+
+type TimeSection = "AM" | "PM" | "AH"
+
+interface TeamRosterShiftTabBarProps {
+  timeSection: TimeSection
+  setTimeSection: (section: TimeSection) => void
+}
+
+const TeamRosterShiftTabBar = ({ timeSection, setTimeSection }: TeamRosterShiftTabBarProps) => {
+  const theme = useTheme()
+
+  const handlePress = (section: TimeSection) => {
+    console.log(section)
+    setTimeSection(section)
+  }
+
+  const sections: { key: TimeSection; icon: IconTypes; bg_color: string }[] = [
+    { key: "AM", icon: "am", bg_color: theme.yellow200.val },
+    { key: "PM", icon: "pm", bg_color: theme.red200.val },
+    { key: "AH", icon: "moon", bg_color: theme.secondary200.val },
+  ]
+
+  const getBackgroundColor = (section: TimeSection) => {
+    if (section !== timeSection) return theme.white500.val
+
+    return sections.find((s) => s.key === section)?.bg_color
+  }
+
+  return (
+    <XStack height={40} width="100%" justifyContent="space-around" alignItems="center">
+      {sections.map((section) => (
+        <XStack
+          key={section.key}
+          flex={1}
+          height="100%"
+          backgroundColor={getBackgroundColor(section.key)}
+          alignItems="center"
+          justifyContent="center"
+          gap={6}
+          borderColor={theme.mono700.val}
+          borderWidth={1}
+          borderTopRightRadius={"$radius.4"}
+          borderTopLeftRadius={"$radius.4"}
+          animation="quick"
+          animateOnly={["backgroundColor"]}
+          onPress={() => handlePress(section.key)}
+        >
+          <Icon icon={section.icon} size={16} color={theme.mono900.val} />
+          <Text fontSize="$4" fontWeight="400" color={theme.mono900.val}>
+            {section.key}
+          </Text>
+        </XStack>
+      ))}
+    </XStack>
+  )
+}
+
+export { TeamRosterShiftTabBar }


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-105)_

Added team roster shift tab component for filtering the dates

Parent component will need a useState that holds the "AM" "PM" "AH" state, like the following

Note that the `sections` const is defined inside the component in order to access `useTheme()` hook, otherwise it wouldve been nice to have it outside the component as a constant map

```javascript
const [timeSection, setTimeSection] = useState<"AM" | "PM" | "AH">("AM")

<TeamRosterShiftTabBar timeSection={timeSection} setTimeSection={setTimeSection} />
```



https://github.com/user-attachments/assets/ebec66e7-cf77-4399-89f9-c851d161c05d



---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
