### PR TITLE
WR-113 feat(general): :sparkles: Update typography for the Lozenge component

### DIFF
--- a/app/components/Lozenge.tsx
+++ b/app/components/Lozenge.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
-import { Button, Text, useTheme } from "tamagui"
+import { Button, useTheme } from "tamagui"
 
+import { BodyText } from "./BodyText"
 import { Icon, IconTypes } from "./Icon"
 
 interface LozengeProps {
@@ -129,9 +130,9 @@ export const Lozenge = ({ type, active = false, onPress }: LozengeProps) => {
       }}
     >
       {buttonIcon && <Icon icon={buttonIcon} size={16} color={buttonTextColor} />}
-      <Text fontSize={12} color={buttonTextColor}>
+      <BodyText variant="body4" color={buttonTextColor} includeFontPadding>
         {buttonText}
-      </Text>
+      </BodyText>
     </Button>
   )
 }


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-113)_


### Changes:
- Replaced `Text` in Lozenge with `BodyText`

iOS:
<img width="132" height="113" alt="Screenshot 2025-09-18 at 2 43 08 pm" src="https://github.com/user-attachments/assets/d2bd975f-1197-4ec1-8a44-4ec9e9cc4dae" />

Android:
<img width="125" height="110" alt="Screenshot 2025-09-18 at 2 43 18 pm" src="https://github.com/user-attachments/assets/476d7e15-e3cc-4b67-bc97-a77e5c56d0e3" />

- The font is getting slightly cut off in the Android version - suggested adjusting the line heights to fix this.



---

<details open><summary><strong>Checklist</strong></summary>

- [ ] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
