### PR TITLE
WR-131 test(general): :white_check_mark: add tests for the lozenge component

### DIFF
--- a/app/components/Lozenge.tsx
+++ b/app/components/Lozenge.tsx
@@ -29,7 +29,7 @@ interface LozengeConfig {
   textColor?: string
 }
 
-const LOZENGE_CONFIG: Record<LozengeProps["type"], LozengeConfig> = {
+export const LOZENGE_CONFIG: Record<LozengeProps["type"], LozengeConfig> = {
   leave: {
     text: "Leave",
     icon: "leave",
@@ -123,13 +123,17 @@ export const Lozenge = ({ type, active = false, onPress }: LozengeProps) => {
       alignSelf="flex-start"
       disabled={!active}
       backgroundColor={buttonBgColor}
+      accessibilityState={{ disabled: !active, selected }}
+      testID={`lozenge-${type}`}
       onPress={() => {
         if (!active) return
         setSelected(!selected)
         onPress?.()
       }}
     >
-      {buttonIcon && <Icon icon={buttonIcon} size={16} color={buttonTextColor} />}
+      {buttonIcon && (
+        <Icon icon={buttonIcon} size={16} color={buttonTextColor} testID={buttonIcon} />
+      )}
       <BodyText variant="body4" color={buttonTextColor} includeFontPadding>
         {buttonText}
       </BodyText>

--- a/app/components/Tests/Lozenge.test.tsx
+++ b/app/components/Tests/Lozenge.test.tsx
@@ -1,0 +1,81 @@
+import { render, fireEvent } from "@testing-library/react-native"
+import { TamaguiProvider, Theme } from "tamagui"
+
+import { ThemeProvider } from "@/theme/context"
+
+import config from "../../tamagui.config"
+import { Lozenge, LOZENGE_CONFIG } from "../Lozenge"
+
+const Providers: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <TamaguiProvider config={config}>
+    <Theme name="light">
+      <ThemeProvider>{children}</ThemeProvider>
+    </Theme>
+  </TamaguiProvider>
+)
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(ui, { wrapper: Providers })
+}
+
+describe("Lozenge", () => {
+  it("renders correct text for each type", () => {
+    Object.keys(LOZENGE_CONFIG).forEach((type) => {
+      const { getByText } = renderWithProviders(<Lozenge type={type as any} active />)
+      const expectedText = LOZENGE_CONFIG[type as keyof typeof LOZENGE_CONFIG].text
+      expect(getByText(expectedText)).toBeTruthy()
+    })
+  })
+
+  it("renders correct icon for each type", () => {
+    const { getByTestId } = renderWithProviders(<Lozenge type="leave" active />)
+    expect(getByTestId("leave")).toBeTruthy()
+
+    const { getByTestId: getByTestId2 } = renderWithProviders(<Lozenge type="swap" active />)
+    expect(getByTestId2("swap")).toBeTruthy()
+
+    const { getByTestId: getByTestId3 } = renderWithProviders(<Lozenge type="event" active />)
+    expect(getByTestId3("openShift")).toBeTruthy()
+
+    const { getByTestId: getByTestId4 } = renderWithProviders(<Lozenge type="openShift" active />)
+    expect(getByTestId4("openShift")).toBeTruthy()
+  })
+
+  it("button disabled when inactive", () => {
+    const { getByTestId } = renderWithProviders(<Lozenge type="leave" active={false} />)
+    const button = getByTestId("lozenge-leave")
+    expect(button.props.accessibilityState.disabled).toBe(true)
+  })
+
+  it("toggles selected state when pressed if active", () => {
+    const { getByTestId } = renderWithProviders(<Lozenge type="leave" active />)
+
+    // check initial state
+    let button = getByTestId("lozenge-leave")
+    expect(button.props.accessibilityState.selected).toBe(false)
+
+    fireEvent.press(button)
+
+    // should be updated state
+    button = getByTestId("lozenge-leave")
+    expect(button.props.accessibilityState.selected).toBe(true)
+  })
+
+  it("calls onPress if pressed when active", () => {
+    const onPressMock = jest.fn()
+    const { getByTestId } = renderWithProviders(
+      <Lozenge type="leave" active onPress={onPressMock} />,
+    )
+    fireEvent.press(getByTestId("lozenge-leave"))
+    expect(onPressMock).toHaveBeenCalled()
+  })
+
+  it("doesn't call onPress when inactive", () => {
+    const onPressMock = jest.fn()
+    const { getByTestId } = renderWithProviders(
+      <Lozenge type="leave" active={false} onPress={onPressMock} />,
+    )
+    fireEvent.press(getByTestId("lozenge-leave"))
+    expect(onPressMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
CURRENTLY ALL TESTS ARE PASSING

had to also add testID and accessibility states into the component so that I could test it (doesn't affect function), can comment out if not testing






---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
