### PR TITLE
NO-00 fix(general): change trigger rebase workflow token

### DIFF
--- a/.github/workflows/trigger-rebase-check
+++ b/.github/workflows/trigger-rebase-check
@@ -11,7 +11,7 @@ jobs:
       - name: Trigger rebase check on open PRs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const prs = await github.rest.pulls.list({
               owner: context.repo.owner,


### PR DESCRIPTION
Unfortunately you'll see that the "trigger-rebase-check" workflow isn't being triggered on main, reason being that it's my PAT token so when other people merge they don't have perms to use my token to re-trigger workflows... I couldn't have foreseen this when making it though because I test it as the same user and pushing to main would require me to assume the identity of another user (cloning the repo under a different git account) which is not worth it imo

Let's just change the token and see if it works, with CI QA'ing is a "merge and find out" situation D:







---

<details open><summary><strong>Checklist</strong></summary>

- [ ] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
