### PR TITLE
WR-121 feat(api): build fetch api for my shifts

### DIFF
--- a/app/screens/RosterScreen/MyRosterScreen.tsx
+++ b/app/screens/RosterScreen/MyRosterScreen.tsx
@@ -4,12 +4,15 @@ import { format } from "date-fns"
 import { useTheme } from "tamagui"
 import { YStack } from "tamagui"
 
+import { ShiftWithNumUsers } from "backend/src/types/event.types"
+
 import { AccordionDropdown } from "@/components/AccordionDropdown"
 import { BodyText } from "@/components/BodyText"
 import { HeaderText } from "@/components/HeaderText"
 import { Screen } from "@/components/Screen"
 import { Text } from "@/components/Text"
 import type { RosterStackParamList } from "@/navigators/DashboardNavigator"
+import { useEvents } from "@/services/hooks/useMyShifts"
 import { $styles } from "@/theme/styles"
 
 type Props = NativeStackScreenProps<RosterStackParamList, "MyRoster">
@@ -42,6 +45,8 @@ export function MyRosterScreen(_props: Props) {
     },
   ]
 
+  const { events, error } = useEvents()
+
   return (
     <Screen preset="scroll" contentContainerStyle={$styles.barContainer}>
       <HeaderText>My Roster</HeaderText>
@@ -52,6 +57,40 @@ export function MyRosterScreen(_props: Props) {
           This is the base screen for <Text weight="bold">My Roster</Text>. Replace this area with
           your roster list/calendar.
         </Text>
+        {events ? (
+          <View>
+            {events.map((event: ShiftWithNumUsers) => (
+              <View key={event.id}>
+                <BodyText variant="body4">
+                  {event.id}: {event.activity?.name} @ {event.location?.name} on{" "}
+                  {format(event.start_time!, "dd MMM yyyy 'at' h:mma")} to{" "}
+                  {format(event.end_time!, "h:mma")} with {event.numUsers}{" "}
+                  {event.numUsers === 1 ? "user" : "users"}
+                </BodyText>
+
+                {/* Users for this event */}
+                {event.eventAssignments && event.eventAssignments.length > 0 ? (
+                  <View>
+                    {event.eventAssignments.map((assignment) => (
+                      <BodyText key={assignment.id} variant="body4">
+                        - {assignment.user?.first_name} {assignment.user?.last_name} (
+                        {assignment.designation?.title ?? "No designation"})
+                      </BodyText>
+                    ))}
+                  </View>
+                ) : null}
+              </View>
+            ))}
+
+            {events.length === 0 && <BodyText variant="body4">No events found</BodyText>}
+          </View>
+        ) : (
+          <BodyText variant="body4">{error}</BodyText>
+        )}
+
+        <BodyText variant="body4" mt={12}>
+          {JSON.stringify(events)}
+        </BodyText>
         <AccordionDropdown sections={accordionSections} />
       </View>
     </Screen>

--- a/app/services/api/eventApi.ts
+++ b/app/services/api/eventApi.ts
@@ -1,0 +1,18 @@
+import { api } from "./apiClient"
+import { ApiResponse } from "../../../backend/src/types/api.types"
+import { ShiftDetails } from "../../../backend/src/types/event.types"
+
+export const eventApi = {
+  getMyShifts: async () => {
+    const response = await api.get<ApiResponse<ShiftDetails[]>>("/events/my-shifts")
+    console.log("\n\n[eventApi.getMyShifts] response:", response.data)
+
+    if (response.ok && response.data) {
+      return response.data
+    }
+    return {
+      success: false,
+      error: (response.data as any)?.error || "Failed to retrieve events",
+    } as ApiResponse<ShiftDetails[]>
+  },
+}

--- a/app/services/api/eventApi.ts
+++ b/app/services/api/eventApi.ts
@@ -1,10 +1,10 @@
 import { api } from "./apiClient"
 import { ApiResponse } from "../../../backend/src/types/api.types"
-import { ShiftDetails } from "../../../backend/src/types/event.types"
+import { ShiftWithNumUsers } from "../../../backend/src/types/event.types"
 
 export const eventApi = {
   getMyShifts: async () => {
-    const response = await api.get<ApiResponse<ShiftDetails[]>>("/events/my-shifts")
+    const response = await api.get<ApiResponse<ShiftWithNumUsers[]>>("/events/my-shifts")
     console.log("\n\n[eventApi.getMyShifts] response:", response.data)
 
     if (response.ok && response.data) {
@@ -13,6 +13,6 @@ export const eventApi = {
     return {
       success: false,
       error: (response.data as any)?.error || "Failed to retrieve events",
-    } as ApiResponse<ShiftDetails[]>
+    } as ApiResponse<ShiftWithNumUsers[]>
   },
 }

--- a/app/services/hooks/useMyShifts.ts
+++ b/app/services/hooks/useMyShifts.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { eventApi } from "../api/eventApi"
+
+export const useEvents = () => {
+  const {
+    data: events,
+    error,
+    isPending,
+    isFetching,
+  } = useQuery({
+    queryKey: ["events"],
+    queryFn: eventApi.getMyShifts,
+    select: (result) => result.data,
+    refetchOnMount: false,
+  })
+
+  return { events, error, isPending, isFetching }
+}

--- a/backend/src/services/event.service.ts
+++ b/backend/src/services/event.service.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from "@prisma/client"
 import type { Event } from ".prisma/client"
-import { ShiftDetails } from "../types/event.types"
+import { ShiftDetails, ShiftWithNumUsers } from "../types/event.types"
 
 export class EventService {
   // Use prisma client for DB operations/interactions -> Prisma is how we interact with the DB
@@ -20,8 +20,8 @@ export class EventService {
     })
   }
 
-  async getMyShifts(user_id: number): Promise<ShiftDetails[]> {
-    return this.prisma.event.findMany({
+  async getMyShifts(user_id: number): Promise<ShiftWithNumUsers[]> {
+    const shifts = await this.prisma.event.findMany({
       where: {
         eventAssignments: {
           // Find all events where there exists at least one event assignment for the user
@@ -55,5 +55,10 @@ export class EventService {
         start_time: "asc",
       },
     })
+
+    return shifts.map((shift: ShiftDetails) => ({
+      ...shift,
+      numUsers: shift.eventAssignments.length,
+    }))
   }
 }

--- a/backend/src/services/event.service.ts
+++ b/backend/src/services/event.service.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from "@prisma/client"
 import type { Event } from ".prisma/client"
+import { ShiftDetails } from "../types/event.types"
 
 export class EventService {
   // Use prisma client for DB operations/interactions -> Prisma is how we interact with the DB
@@ -19,14 +20,40 @@ export class EventService {
     })
   }
 
-  // Retrieve events for a specific activity ID (refer to schema.prisma or diagram for relation)
-  async getActivityEvents(activity_id: string) {
-    // FInd many as one activity can have multiple events
+  async getMyShifts(user_id: number): Promise<ShiftDetails[]> {
     return this.prisma.event.findMany({
       where: {
-        // activity_id,
+        eventAssignments: {
+          // Find all events where there exists at least one event assignment for the user
+          some: {
+            user_id: user_id,
+          },
+        },
       },
-      include: { activity: true },
+      select: {
+        id: true,
+        start_time: true,
+        end_time: true,
+        on_call: true,
+        activity: true,
+        location: true,
+        eventAssignments: {
+          select: {
+            id: true,
+            user: {
+              select: {
+                id: true,
+                first_name: true,
+                last_name: true,
+              },
+            },
+            designation: true,
+          },
+        },
+      },
+      orderBy: {
+        start_time: "asc",
+      },
     })
   }
 }

--- a/backend/src/types/event.types.ts
+++ b/backend/src/types/event.types.ts
@@ -1,0 +1,25 @@
+import { Prisma } from ".prisma/client"
+
+export type ShiftDetails = Prisma.EventGetPayload<{
+  select: {
+    id: true
+    start_time: true
+    end_time: true
+    on_call: true
+    activity: true
+    location: true
+    eventAssignments: {
+      select: {
+        id: true
+        user: {
+          select: {
+            id: true
+            first_name: true
+            last_name: true
+          }
+        }
+        designation: true
+      }
+    }
+  }
+}>

--- a/backend/src/types/event.types.ts
+++ b/backend/src/types/event.types.ts
@@ -23,3 +23,7 @@ export type ShiftDetails = Prisma.EventGetPayload<{
     }
   }
 }>
+
+export type ShiftWithNumUsers = ShiftDetails & {
+  numUsers: number
+}


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-121)_

### Updates 27th Sept Sat

now that tanstack query is merged in, updated to use tanstack AND
- added extra field numUsers for FE to leverage
- extended EventData type and used that for this hook instead --> justification is not every fetch of the EventData will need Event Assignment, and modifying the original type itself is not truthful to the DB, so extending it feels the most correct for an extension of the original datatype

note the "with 3 users" etc.
<img width="512" height="114" alt="image" src="https://github.com/user-attachments/assets/0075aa8c-710f-42c2-9e97-191135c091d9" />


<img width="374" height="101" alt="image" src="https://github.com/user-attachments/assets/9a288626-9c24-4e7f-b333-1c6716841fba" />


### Updates 26th Sept Fri

now that WR-128 is merged, updated FE services to be in designated eventsApi.ts
- fetching user id + first name + last name
- note that I did not fetch the entire user model, I think that if they click into something and segue into a new page, there should be a refetch given the selected user ID instead of holding onto a million user objects


note that the user with our access credentials is called "John Smith" with userID 1:

<img width="414" height="828" alt="image" src="https://github.com/user-attachments/assets/c5a4b275-3b6c-4f5c-accb-6f5fb2c86804" />



---

DRAFT until [WR-128](https://github.com/rcchao/weroster-team41/pull/56) is merged (I want to leverage some abstractions here)

- Fetch api for my roster page (my shifts!)
- service layer is a `prisma.event.findMany` call and therefore returns in the shape of `EventData[]`
- Filtered to only retrieve the events which have event assignments with at least one of the users being the key user (recall events - users is many to many, with event assignments essentially acting as an associative entity between the two)
- ordered by start_time since we are displaying chronologically
- displayed the data in frontend using a javascript `.map` function to show roughly how to use the data fetched from the `useEvents()` hook!

The devious green box on my prisma studio screenshot shows that it is correctly fetching the only two events assigned to this user! (user_id = 1)

<img width="331" height="74" alt="image" src="https://github.com/user-attachments/assets/f1dcfcc0-abb1-400f-8a1e-3853dde350cc" />


<img width="399" height="839" alt="image" src="https://github.com/user-attachments/assets/151e9602-5338-4da2-b104-1bb1be73371a" />

<img width="2154" height="1708" alt="image" src="https://github.com/user-attachments/assets/c234c24d-40c2-4ff4-bd25-d55600d38803" />


---

<details open><summary><strong>Checklist</strong></summary>

- [ ] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
