### PR TITLE
WR-146 feat(api): set up tanstack query

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -21,6 +21,7 @@ import "./utils/gestureHandler"
 import { useEffect, useState } from "react"
 import { useFonts } from "expo-font"
 import * as Linking from "expo-linking"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { KeyboardProvider } from "react-native-keyboard-controller"
 import { initialWindowMetrics, SafeAreaProvider } from "react-native-safe-area-context"
 import { TamaguiProvider } from "tamagui"
@@ -36,6 +37,7 @@ import { loadDateFnsLocale } from "./utils/formatDate"
 import * as storage from "./utils/storage"
 
 export const NAVIGATION_PERSISTENCE_KEY = "NAVIGATION_STATE"
+const queryClient = new QueryClient()
 
 // Web linking configuration
 const prefix = Linking.createURL("/")
@@ -98,20 +100,22 @@ export function App() {
 
   // otherwise, we're ready to render the app
   return (
-    <TamaguiProvider config={tamaguiConfig}>
-      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-        <KeyboardProvider>
-          <AuthProvider>
-            <ThemeProvider>
-              <AppNavigator
-                linking={linking}
-                initialState={initialNavigationState}
-                onStateChange={onNavigationStateChange}
-              />
-            </ThemeProvider>
-          </AuthProvider>
-        </KeyboardProvider>
-      </SafeAreaProvider>
-    </TamaguiProvider>
+    <QueryClientProvider client={queryClient}>
+      <TamaguiProvider config={tamaguiConfig}>
+        <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+          <KeyboardProvider>
+            <AuthProvider>
+              <ThemeProvider>
+                <AppNavigator
+                  linking={linking}
+                  initialState={initialNavigationState}
+                  onStateChange={onNavigationStateChange}
+                />
+              </ThemeProvider>
+            </AuthProvider>
+          </KeyboardProvider>
+        </SafeAreaProvider>
+      </TamaguiProvider>
+    </QueryClientProvider>
   )
 }

--- a/app/services/hooks/useDashboardPreferences.ts
+++ b/app/services/hooks/useDashboardPreferences.ts
@@ -1,36 +1,19 @@
-import { useState, useEffect } from "react"
-
-import { DashboardPreferences } from "backend/src/types/settings.types"
+import { useQuery } from "@tanstack/react-query"
 
 import { settingsApi } from "../api/settingsApi"
 
 export const useDashboardPreferences = () => {
-  const [dashboardPreferences, setDashboardPreferences] = useState<DashboardPreferences | null>(
-    null,
-  )
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const {
+    data: dashboardPreferences,
+    error,
+    isPending,
+    isFetching,
+  } = useQuery({
+    queryKey: ["dashboard-settings"],
+    queryFn: settingsApi.getDashboardPreferences,
+    select: (result) => result.data,
+    refetchOnMount: false,
+  })
 
-  const fetchDashboardPreferences = async () => {
-    setLoading(true)
-    setError(null)
-
-    const result = await settingsApi.getDashboardPreferences()
-
-    if (result.success && result.data) {
-      setDashboardPreferences(result.data)
-    } else {
-      setError(result.error || "Failed to fetch dashboard settings")
-    }
-
-    setLoading(false)
-  }
-
-  useEffect(() => {
-    if (!dashboardPreferences) {
-      fetchDashboardPreferences()
-    }
-  }, [])
-
-  return { dashboardPreferences, loading, error, refetch: fetchDashboardPreferences }
+  return { dashboardPreferences, error, isPending, isFetching }
 }

--- a/app/services/hooks/useProfile.ts
+++ b/app/services/hooks/useProfile.ts
@@ -1,34 +1,19 @@
-import { useState, useEffect } from "react"
-
-import { ProfileData } from "backend/src/types/auth.types"
+import { useQuery } from "@tanstack/react-query"
 
 import { authApi } from "../api/authApi"
 
 export const useProfile = () => {
-  const [profile, setProfile] = useState<ProfileData | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const {
+    data: profile,
+    error,
+    isPending,
+    isFetching,
+  } = useQuery({
+    queryKey: ["profile"],
+    queryFn: authApi.getProfile,
+    select: (result) => result.data,
+    refetchOnMount: false,
+  })
 
-  const fetchProfile = async () => {
-    setLoading(true)
-    setError(null)
-
-    const result = await authApi.getProfile()
-
-    if (result.success && result.data) {
-      setProfile(result.data)
-    } else {
-      setError(result.error || "Failed to fetch profile")
-    }
-
-    setLoading(false)
-  }
-
-  useEffect(() => {
-    if (!profile) {
-      fetchProfile()
-    }
-  }, [])
-
-  return { profile, loading, error, refetch: fetchProfile }
+  return { profile, error, isPending, isFetching }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/native-stack": "^7.2.0",
         "@tamagui/config": "^1.132.23",
+        "@tanstack/react-query": "^5.90.2",
         "apisauce": "3.1.1",
         "date-fns": "^4.1.0",
         "expo": "^53.0.15",
@@ -6307,6 +6308,32 @@
       "integrity": "sha512-djbRW7FWzuc9bCIVXG00pVa6McM8/H8R4JOL+szxSy1iAo0P2k0OzWfBb+ZbbjTye068fBPGIniq4X7+3huS1Q==",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/react-native": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.2.0",
     "@tamagui/config": "^1.132.23",
+    "@tanstack/react-query": "^5.90.2",
     "apisauce": "3.1.1",
     "date-fns": "^4.1.0",
     "expo": "^53.0.15",


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-146)_

Old hook data has now been cached! It loads in once on initial fetch and that's it (you can check the console logs for each time the endpoint is called if you want to confirm).

[Made a decision doc](https://comp30022weroster2025s2.atlassian.net/wiki/spaces/CWR2/pages/72056835/W9+Data+Fetching+Methodology+Tanstack+Query) on why this change is so so so much better than what we were doing before. This PR just handles existing GETs but `useMutation` is going to make making POSTs that much easier too.


1. Set up tanstack query: install and create query client for app entry
2. Replace my old manually created hooks (`useProfile` and when merged and `useDashboardPreferences`) with tanstack query



**NOTES:**
We might want to refactor the hooks file structure to have nested folders for different domains, e.g. auth or settings and have individual hooks inside. This will likely just match what we have configured for the routes. Will cross that bridge when we get there

If you're wondering:
`isPending`: No data in the cache at all. Is doing the initial fetch -> Rely on this for first time loads
`isFetching`: Fetching is in progress, including initial fetch -> Rely on this for background refreshes
`isLoading`: Basically `isPending && isFetching`

A query can be in one of the following states at any one point in time:
`isLoading`, `isError` or `isSuccess`


---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
