### PR TITLE
WR-149 test(general): :white_check_mark: added tests for requesttypeicon component

### DIFF
--- a/app/components/RequestTypeIcon.tsx
+++ b/app/components/RequestTypeIcon.tsx
@@ -2,14 +2,14 @@ import { Group, useTheme } from "tamagui"
 
 import { Icon, IconTypes } from "./Icon"
 
-const REQUEST_TYPE_ICON_MAP: Record<string, IconTypes> = {
+export const REQUEST_TYPE_ICON_MAP: Record<string, IconTypes> = {
   leave: "leave",
   swap: "swap",
   openShift: "openShift",
   default: "meh",
 }
 
-const REQUEST_TYPE_COLOR_MAP: Record<string, string> = {
+export const REQUEST_TYPE_COLOR_MAP: Record<string, string> = {
   leave: "secondary400",
   swap: "yellow400",
   openShift: "green500",
@@ -30,6 +30,7 @@ export const RequestTypeIcon = ({ requestType }: RequestTypeIconProps) => {
 
   return (
     <Group
+      testID="request-type-icon-container"
       width={74}
       height={74}
       bg={bgColor}
@@ -38,7 +39,7 @@ export const RequestTypeIcon = ({ requestType }: RequestTypeIconProps) => {
       justifyContent="center"
     >
       <Group.Item>
-        <Icon icon={icon} color={iconColor} size={24} />
+        <Icon testID={`request-type-icon-${requestType}`} icon={icon} color={iconColor} size={24} />
       </Group.Item>
     </Group>
   )

--- a/app/components/Tests/RequestTypeIcon.test.tsx
+++ b/app/components/Tests/RequestTypeIcon.test.tsx
@@ -1,0 +1,73 @@
+import { render } from "@testing-library/react-native"
+import { TamaguiProvider } from "tamagui"
+
+import {
+  RequestTypeIcon,
+  REQUEST_TYPE_COLOR_MAP,
+  REQUEST_TYPE_ICON_MAP,
+} from "@/components/RequestTypeIcon"
+
+import config from "../../tamagui.config"
+
+jest.mock("../Icon", () => ({
+  Icon: ({ icon, color, size, testID }: any) => {
+    const MockIcon = require("react-native").Text
+    return <MockIcon testID={testID}>{`Icon: ${icon}, Color: ${color}, Size: ${size}`}</MockIcon>
+  },
+}))
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <TamaguiProvider config={config} disableInjectCSS>
+    {children}
+  </TamaguiProvider>
+)
+
+describe("RequestTypeIcon", () => {
+  const renderComponent = (requestType: string) => {
+    return render(
+      <TestWrapper>
+        <RequestTypeIcon requestType={requestType} />
+      </TestWrapper>,
+    )
+  }
+
+  describe("Request Type Mapping", () => {
+    it("renders leave request icon with correct styling", () => {
+      Object.keys(REQUEST_TYPE_ICON_MAP)
+        .filter((type) => type !== "default")
+        .forEach((requestType) => {
+          const { getByTestId } = renderComponent(requestType)
+          const expectedIcon = REQUEST_TYPE_ICON_MAP[requestType]
+
+          const iconElement = getByTestId(`request-type-icon-${requestType}`)
+          expect(iconElement).toBeTruthy()
+          expect(iconElement.props.children).toContain(expectedIcon)
+        })
+    })
+
+    it("uses correct color mapping for each request type", () => {
+      Object.keys(REQUEST_TYPE_COLOR_MAP)
+        .filter((type) => type !== "default")
+        .forEach((requestType) => {
+          const { getByTestId } = renderComponent(requestType)
+          const container = getByTestId("request-type-icon-container")
+
+          expect(container).toBeTruthy()
+        })
+    })
+  })
+
+  describe("Default Fallback", () => {
+    it("renders default icon and color for unknown request type", () => {
+      const unknownTypes = ["unknown", "", "INVALID", null, undefined]
+
+      unknownTypes.forEach((unknownType) => {
+        const { getByTestId } = renderComponent(unknownType as string)
+        const iconElement = getByTestId(`request-type-icon-${unknownType}`)
+
+        expect(iconElement).toBeTruthy()
+        expect(iconElement.props.children).toContain(REQUEST_TYPE_ICON_MAP.default)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Component tests for RequestTypeIcon component!

Checks for correct rendering based on the request type, and ensures the fallback works correctly.




---

<details open><summary><strong>Checklist</strong></summary>

- [ ] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
