### PR TITLE
WR-145 feat(my-roster): Create base calendar component with event data

### DIFF
--- a/app/components/RosterCalendar.tsx
+++ b/app/components/RosterCalendar.tsx
@@ -1,54 +1,103 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
+import { format, parseISO, toDate } from "date-fns"
 import { AgendaList, CalendarProvider, ExpandableCalendar } from "react-native-calendars"
 import { View, Text } from "tamagui"
 
-// Mock data
-const ITEMS = [
-  {
-    title: "2025-09-24",
-    data: [
-      { id: "1", name: "Morning Yoga", time: "07:00 AM" },
-      { id: "2", name: "Team Standup", time: "09:30 AM" },
-      { id: "3", name: "Project Review Meeting", time: "02:00 PM" },
-    ],
-  },
-  {
-    title: "2025-09-25",
-    data: [
-      { id: "4", name: "Doctor Appointment", time: "10:00 AM" },
-      { id: "5", name: "Lunch with Sarah", time: "12:30 PM" },
-      { id: "6", name: "Code Review", time: "04:00 PM" },
-    ],
-  },
-  {
-    title: "2025-09-26",
-    data: [
-      { id: "7", name: "Gym", time: "06:30 AM" },
-      { id: "8", name: "Design Sprint Workshop", time: "11:00 AM" },
-      { id: "9", name: "Dinner with Parents", time: "07:00 PM" },
-    ],
-  },
-]
+import { ShiftWithNumUsers } from "backend/src/types/event.types"
 
-export const RosterCalendar = () => {
-  const [selected, setSelected] = useState("2025-09-24")
+interface RosterCalendarProps {
+  events: ShiftWithNumUsers[] | undefined
+}
+
+type AgendaItem = {
+  id: string
+  name: string
+  timeRange: string
+  location?: string | null
+  start: Date
+  numUsers: number
+}
+
+type AgendaSection = {
+  title: string
+  data: AgendaItem[]
+}
+
+// Group the events by day
+function buildAgendaSections(data: ShiftWithNumUsers[] | undefined) {
+  const safe = Array.isArray(data) ? data : []
+  const byDate: Record<string, AgendaItem[]> = {}
+
+  for (const ev of safe) {
+    const start = toDate(ev.start_time as any)
+    const end = toDate(ev.end_time as any)
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) continue // skip bad rows
+
+    const dateKey = format(start, "yyyy-MM-dd")
+
+    const item: AgendaItem = {
+      id: String(ev.id),
+      name: ev.activity?.name ?? "Shift",
+      timeRange: `${format(start, "h:mm a")} – ${format(end, "h:mm a")}`,
+      location: ev.location?.name ?? null,
+      start,
+      numUsers: (ev as any).numUsers ?? 0,
+    }
+
+    if (!byDate[dateKey]) byDate[dateKey] = []
+    byDate[dateKey].push(item)
+  }
+
+  const sections: AgendaSection[] = Object.entries(byDate)
+    .sort(([a], [b]) => (a < b ? -1 : 1)) // Sort dates in chronological order
+    .map(([dateKey, items]) => ({
+      title: dateKey,
+      data: items.sort((a, b) => a.start.getTime() - b.start.getTime()),
+    }))
+
+  // Build calendar markings to show on the calendar.
+  const marked: Record<string, any> = {}
+  for (const dateKey of Object.keys(byDate)) marked[dateKey] = { marked: true }
+
+  return { sections, marked }
+}
+
+export const RosterCalendar = ({ events }: RosterCalendarProps) => {
+  // Default day chosen should be today
+  const firstDate = format(new Date(), "yyyy-MM-dd")
+
+  const [selected, setSelected] = useState(firstDate)
+
+  const { sections, marked } = useMemo(() => buildAgendaSections(events), [events])
+  const markedDates = useMemo(
+    () => ({
+      ...marked,
+      [selected]: { ...(marked[selected] ?? {}), selected: true },
+    }),
+    [marked, selected],
+  )
   return (
-    <CalendarProvider date={selected} onDateChanged={(d) => setSelected(d)} showTodayButton>
-      <ExpandableCalendar
-        firstDay={1}
-        markedDates={{
-          [selected]: { selected: true },
-        }}
-        allowShadow
-      />
+    <CalendarProvider date={selected} onDateChanged={setSelected} showTodayButton>
+      <ExpandableCalendar firstDay={1} markedDates={markedDates} allowShadow />
       <AgendaList
-        sections={ITEMS}
+        sections={sections}
+        keyExtractor={(item) => item.id}
+        dayFormatter={(day) => format(parseISO(day), "EEE, d MMM")}
         renderItem={({ item }) => (
-          <View>
-            <Text>{item.time}</Text>
-            <Text>{item.name}</Text>
+          <View paddingHorizontal="$3" paddingVertical="$2">
+            <Text fontWeight="600">{item.timeRange}</Text>
+            <Text>
+              {item.name}
+              {item.location ? ` · ${item.location}` : ""}
+            </Text>
+            <Text>{item.numUsers} others working</Text>
           </View>
         )}
+        ListEmptyComponent={
+          <View padding="$4">
+            <Text>No shifts found.</Text>
+          </View>
+        }
       />
     </CalendarProvider>
   )

--- a/app/components/RosterCalendar.tsx
+++ b/app/components/RosterCalendar.tsx
@@ -90,7 +90,7 @@ export const RosterCalendar = ({ events }: RosterCalendarProps) => {
               {item.name}
               {item.location ? ` · ${item.location}` : ""}
             </Text>
-            <Text>{item.numUsers} others working</Text>
+            <Text>{item.numUsers - 1} others working</Text>
           </View>
         )}
         ListEmptyComponent={

--- a/app/components/RosterCalendar.tsx
+++ b/app/components/RosterCalendar.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react"
+import { AgendaList, CalendarProvider, ExpandableCalendar } from "react-native-calendars"
+import { View, Text } from "tamagui"
+
+// Mock data
+const ITEMS = [
+  {
+    title: "2025-09-24",
+    data: [
+      { id: "1", name: "Morning Yoga", time: "07:00 AM" },
+      { id: "2", name: "Team Standup", time: "09:30 AM" },
+      { id: "3", name: "Project Review Meeting", time: "02:00 PM" },
+    ],
+  },
+  {
+    title: "2025-09-25",
+    data: [
+      { id: "4", name: "Doctor Appointment", time: "10:00 AM" },
+      { id: "5", name: "Lunch with Sarah", time: "12:30 PM" },
+      { id: "6", name: "Code Review", time: "04:00 PM" },
+    ],
+  },
+  {
+    title: "2025-09-26",
+    data: [
+      { id: "7", name: "Gym", time: "06:30 AM" },
+      { id: "8", name: "Design Sprint Workshop", time: "11:00 AM" },
+      { id: "9", name: "Dinner with Parents", time: "07:00 PM" },
+    ],
+  },
+]
+
+export const RosterCalendar = () => {
+  const [selected, setSelected] = useState("2025-09-24")
+  return (
+    <CalendarProvider date={selected} onDateChanged={(d) => setSelected(d)} showTodayButton>
+      <ExpandableCalendar
+        firstDay={1}
+        markedDates={{
+          [selected]: { selected: true },
+        }}
+        allowShadow
+      />
+      <AgendaList
+        sections={ITEMS}
+        renderItem={({ item }) => (
+          <View>
+            <Text>{item.time}</Text>
+            <Text>{item.name}</Text>
+          </View>
+        )}
+      />
+    </CalendarProvider>
+  )
+}

--- a/app/screens/RosterScreen/MyRosterScreen.tsx
+++ b/app/screens/RosterScreen/MyRosterScreen.tsx
@@ -1,101 +1,38 @@
-import { View } from "react-native"
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
-import { format } from "date-fns"
-import { useTheme } from "tamagui"
-import { YStack } from "tamagui"
 
-import { ShiftWithNumUsers } from "backend/src/types/event.types"
-
-import { AccordionDropdown } from "@/components/AccordionDropdown"
-import { BodyText } from "@/components/BodyText"
-import { HeaderText } from "@/components/HeaderText"
 import { RosterCalendar } from "@/components/RosterCalendar"
-import { Screen } from "@/components/Screen"
-import { Text } from "@/components/Text"
 import type { RosterStackParamList } from "@/navigators/DashboardNavigator"
 import { useEvents } from "@/services/hooks/useMyShifts"
-import { $styles } from "@/theme/styles"
 
 type Props = NativeStackScreenProps<RosterStackParamList, "MyRoster">
 
 export function MyRosterScreen(_props: Props) {
-  const themes = useTheme()
-
   const today = new Date()
   const tomorrow = new Date()
   tomorrow.setDate(today.getDate() + 1)
 
-  const accordionSections = [
-    {
-      sectionText: format(today, "EEE, d MMM"),
-      isCurrent: true,
-      children: (
-        <YStack padding={16} backgroundColor={themes.white100.val}>
-          <BodyText>Today&apos;s Shifts Here</BodyText>
-        </YStack>
-      ),
-    },
-    {
-      sectionText: format(tomorrow, "EEE, d MMM"),
-      isCurrent: false,
-      children: (
-        <YStack padding={16} backgroundColor={themes.white100.val}>
-          <BodyText>Tomorrow&apos;s Shifts Here</BodyText>
-        </YStack>
-      ),
-    },
-  ]
+  // const accordionSections = [
+  //   {
+  //     sectionText: format(today, "EEE, d MMM"),
+  //     isCurrent: true,
+  //     children: (
+  //       <YStack padding={16} backgroundColor={themes.white100.val}>
+  //         <BodyText>Today&apos;s Shifts Here</BodyText>
+  //       </YStack>
+  //     ),
+  //   },
+  //   {
+  //     sectionText: format(tomorrow, "EEE, d MMM"),
+  //     isCurrent: false,
+  //     children: (
+  //       <YStack padding={16} backgroundColor={themes.white100.val}>
+  //         <BodyText>Tomorrow&apos;s Shifts Here</BodyText>
+  //       </YStack>
+  //     ),
+  //   },
+  // ]
 
-  const { events, error } = useEvents()
+  const { events } = useEvents()
 
-  return (
-    <Screen preset="scroll" contentContainerStyle={$styles.barContainer}>
-      <RosterCalendar events={events ?? []} />
-
-      <HeaderText>My Roster</HeaderText>
-
-      <View>
-        <Text preset="subheading">Coming soon</Text>
-        <Text>
-          This is the base screen for <Text weight="bold">My Roster</Text>. Replace this area with
-          your roster list/calendar.
-        </Text>
-        {events ? (
-          <View>
-            {events.map((event: ShiftWithNumUsers) => (
-              <View key={event.id}>
-                <BodyText variant="body4">
-                  {event.id}: {event.activity?.name} @ {event.location?.name} on{" "}
-                  {format(event.start_time!, "dd MMM yyyy 'at' h:mma")} to{" "}
-                  {format(event.end_time!, "h:mma")} with {event.numUsers}{" "}
-                  {event.numUsers === 1 ? "user" : "users"}
-                </BodyText>
-
-                {/* Users for this event */}
-                {event.eventAssignments && event.eventAssignments.length > 0 ? (
-                  <View>
-                    {event.eventAssignments.map((assignment) => (
-                      <BodyText key={assignment.id} variant="body4">
-                        - {assignment.user?.first_name} {assignment.user?.last_name} (
-                        {assignment.designation?.title ?? "No designation"})
-                      </BodyText>
-                    ))}
-                  </View>
-                ) : null}
-              </View>
-            ))}
-
-            {events.length === 0 && <BodyText variant="body4">No events found</BodyText>}
-          </View>
-        ) : (
-          <BodyText variant="body4">{error}</BodyText>
-        )}
-
-        <BodyText variant="body4" mt={12}>
-          {JSON.stringify(events)}
-        </BodyText>
-        <AccordionDropdown sections={accordionSections} />
-      </View>
-    </Screen>
-  )
+  return <RosterCalendar events={events ?? []} />
 }

--- a/app/screens/RosterScreen/MyRosterScreen.tsx
+++ b/app/screens/RosterScreen/MyRosterScreen.tsx
@@ -50,7 +50,8 @@ export function MyRosterScreen(_props: Props) {
 
   return (
     <Screen preset="scroll" contentContainerStyle={$styles.barContainer}>
-      <RosterCalendar />
+      <RosterCalendar events={events ?? []} />
+
       <HeaderText>My Roster</HeaderText>
 
       <View>

--- a/app/screens/RosterScreen/MyRosterScreen.tsx
+++ b/app/screens/RosterScreen/MyRosterScreen.tsx
@@ -9,6 +9,7 @@ import { ShiftWithNumUsers } from "backend/src/types/event.types"
 import { AccordionDropdown } from "@/components/AccordionDropdown"
 import { BodyText } from "@/components/BodyText"
 import { HeaderText } from "@/components/HeaderText"
+import { RosterCalendar } from "@/components/RosterCalendar"
 import { Screen } from "@/components/Screen"
 import { Text } from "@/components/Text"
 import type { RosterStackParamList } from "@/navigators/DashboardNavigator"
@@ -49,6 +50,7 @@ export function MyRosterScreen(_props: Props) {
 
   return (
     <Screen preset="scroll" contentContainerStyle={$styles.barContainer}>
+      <RosterCalendar />
       <HeaderText>My Roster</HeaderText>
 
       <View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "react-hook-form": "^7.62.0",
         "react-i18next": "^15.0.1",
         "react-native": "0.79.5",
+        "react-native-calendars": "^1.1313.0",
         "react-native-draggable-flatlist": "^4.0.3",
         "react-native-drawer-layout": "^4.0.1",
         "react-native-edge-to-edge": "1.6.0",
@@ -15161,7 +15162,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -16199,6 +16199,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/moti": {
@@ -17244,7 +17254,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -17256,7 +17265,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
@@ -17582,6 +17590,38 @@
         }
       }
     },
+    "node_modules/react-native-calendars": {
+      "version": "1.1313.0",
+      "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.1313.0.tgz",
+      "integrity": "sha512-YQ7Vg57rBRVymolamYDTxZ0lPOELTDHQbTukTWdxR47aRBYJwKI6ocRbwcY5gYgyDwNgJS4uLGu5AvmYS74LYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.1",
+        "lodash": "^4.17.15",
+        "memoize-one": "^5.2.1",
+        "prop-types": "^15.5.10",
+        "react-native-safe-area-context": "4.5.0",
+        "react-native-swipe-gestures": "^1.0.5",
+        "recyclerlistview": "^4.0.0",
+        "xdate": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "moment": "^2.29.4"
+      }
+    },
+    "node_modules/react-native-calendars/node_modules/react-native-safe-area-context": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
+      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-draggable-flatlist": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/react-native-draggable-flatlist/-/react-native-draggable-flatlist-4.0.3.tgz",
@@ -17744,6 +17784,12 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-swipe-gestures": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
+      "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
+      "license": "MIT"
     },
     "node_modules/react-native-web": {
       "version": "0.20.0",
@@ -17989,6 +18035,21 @@
       "peerDependencies": {
         "react-native-mmkv": "*",
         "reactotron-core-client": "*"
+      }
+    },
+    "node_modules/recyclerlistview": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.3.tgz",
+      "integrity": "sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "4.0.8",
+        "prop-types": "15.8.1",
+        "ts-object-utils": "0.0.5"
+      },
+      "peerDependencies": {
+        "react": ">= 15.2.1",
+        "react-native": ">= 0.30.0"
       }
     },
     "node_modules/redent": {
@@ -20265,6 +20326,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ts-object-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
+      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
+      "license": "ISC"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -21242,6 +21309,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/xdate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.3.tgz",
+      "integrity": "sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==",
+      "license": "(MIT OR GPL-2.0)"
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react-hook-form": "^7.62.0",
     "react-i18next": "^15.0.1",
     "react-native": "0.79.5",
+    "react-native-calendars": "^1.1313.0",
     "react-native-draggable-flatlist": "^4.0.3",
     "react-native-drawer-layout": "^4.0.1",
     "react-native-edge-to-edge": "1.6.0",


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-145)_

### Changes:
- Implemented the base `react-native-calendar` calendar and passed in event data using the `useEvents()` hook.
- Note that the calendar must sit in the screen on its own, as the `CalendarProvider` component provides its own scrolling (wrapping it in `Screen` or `View` messed with it). 

iOS:

https://github.com/user-attachments/assets/b0c39b2e-0183-41e4-a0f0-d2857f9a9d97


Android:

https://github.com/user-attachments/assets/3b518b29-51c3-444a-ba8b-65ce2164cef8




---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
