### PR TITLE
WR-123 feat(auth): expose user hospital id in requests

### DIFF
--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -9,12 +9,14 @@ declare module "express-serve-static-core" {
     userId?: number
     userEmail?: string
     user?: User
+    userHospitalId?: number
   }
 }
 
 interface JWTPayload {
   userId: number
   email: string
+  userHospitalId: number
 }
 
 // Authentication middleware to verify JWT tokens and attach user info to the request object
@@ -34,6 +36,7 @@ export const authenticate = (req: Request, res: Response, next: NextFunction): v
     }
 
     const token = parts[1]
+    console.log("\n\n\n TOKEN", token)
 
     try {
       // Decode and verify existing JWT token
@@ -42,6 +45,7 @@ export const authenticate = (req: Request, res: Response, next: NextFunction): v
       // Attach user info to request object for downstream handlers
       req.userId = decoded.userId
       req.userEmail = decoded.email
+      req.userHospitalId = decoded.userHospitalId
 
       // next() call passes control to the next function in the route handler chain
       next()

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -13,6 +13,7 @@ export class AuthService {
       {
         userId: user.id,
         email: user.email,
+        userHospitalId: user.hospital_id,
         role: user.role,
       },
       process.env.JWT_SECRET as string,


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-123)_

Separate PR to address accessing the user's hospital ID through API requests, as needed here: https://github.com/rcchao/weroster-team41/pull/81/files#r2400779059

Auth context and MMKV storage is exclusively for the frontend auth context, not for the backend. In order to have the backend gain access to the user's hospital ID as a global context the same way we do for the user IDs, I've added that field in to what we need for JWT token signing and decoding

Note that in order for you to make use of the user's hospital ID and see the results in e.g. postman, you'll need to regenerate the bearer token (as it is now signed differently!) and use that for your requests. I've added in a console.log to make this convenient, I'll delete it in my other WR-123 PR after Aaron and I finish using it. 








---

<details open><summary><strong>Checklist</strong></summary>

- [ ] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
