### PR TITLE
WR-126 feat(team-roster): build out team-roster api

### DIFF
--- a/app/screens/RosterScreen/TeamRosterScreen.tsx
+++ b/app/screens/RosterScreen/TeamRosterScreen.tsx
@@ -4,6 +4,7 @@ import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import { Screen } from "@/components/Screen"
 import { Text } from "@/components/Text"
 import type { RosterStackParamList } from "@/navigators/DashboardNavigator"
+import { useTeamShifts } from "@/services/hooks/useTeamShifts"
 import { useAppTheme } from "@/theme/context"
 import { $styles } from "@/theme/styles"
 
@@ -11,6 +12,23 @@ type Props = NativeStackScreenProps<RosterStackParamList, "TeamRoster">
 
 export function TeamRosterScreen(_props: Props) {
   const { themed } = useAppTheme()
+  const { teamShifts, isPending, error } = useTeamShifts(20, 0, 2025, "AM")
+
+  if (isPending) {
+    return (
+      <Screen preset="scroll" contentContainerStyle={$styles.container}>
+        <Text>Loading...</Text>
+      </Screen>
+    )
+  }
+
+  if (error) {
+    return (
+      <Screen preset="scroll" contentContainerStyle={$styles.container}>
+        <Text>Error: {error.message}</Text>
+      </Screen>
+    )
+  }
 
   return (
     <Screen preset="scroll" contentContainerStyle={$styles.container}>
@@ -18,13 +36,43 @@ export function TeamRosterScreen(_props: Props) {
         Team Roster
       </Text>
 
-      <View>
-        <Text preset="subheading">Coming soon</Text>
-        <Text>
-          This is the base screen for the <Text weight="bold">Team Roster</Text>. Add filters,
-          groupings, and list/calendar UI here.
-        </Text>
-      </View>
+      {teamShifts?.map((campus) => (
+        <View key={campus.id}>
+          <Text>Campus: {campus.name}</Text>
+
+          {campus.locations.map((location) => (
+            <View key={location.id}>
+              <Text>Location: {location.name}</Text>
+
+              {location.events.length === 0 ? (
+                <Text>No events scheduled</Text>
+              ) : (
+                location.events.map((event) => (
+                  <View key={event.id}>
+                    <Text>Event ID: {event.id}</Text>
+                    <Text>Activity: {event.activity}</Text>
+
+                    {event.eventAssignments.length === 0 ? (
+                      <Text>No staff assigned</Text>
+                    ) : (
+                      <View>
+                        <Text>Assigned Staff:</Text>
+                        {event.eventAssignments.map((assignment) => (
+                          <View key={assignment.id}>
+                            <Text>
+                              • {assignment.first_name} {assignment.last_name}
+                            </Text>
+                          </View>
+                        ))}
+                      </View>
+                    )}
+                  </View>
+                ))
+              )}
+            </View>
+          ))}
+        </View>
+      ))}
     </Screen>
   )
 }

--- a/app/services/api/eventApi.ts
+++ b/app/services/api/eventApi.ts
@@ -1,6 +1,6 @@
 import { api } from "./apiClient"
 import { ApiResponse } from "../../../backend/src/types/api.types"
-import { OpenShift, ShiftWithNumUsers } from "../../../backend/src/types/event.types"
+import { OpenShift, ShiftWithNumUsers, TeamShift } from "../../../backend/src/types/event.types"
 
 export const eventApi = {
   getMyShifts: async () => {
@@ -40,5 +40,20 @@ export const eventApi = {
       success: false,
       error: (response.data as any)?.error || "Failed to retrieve event",
     } as ApiResponse<ShiftWithNumUsers>
+  },
+
+  getTeamShifts: async (day: number, month: number, year: number, session: string) => {
+    const response = await api.get<ApiResponse<TeamShift[]>>(
+      `/events/team-shifts?day=${day}&month=${month}&year=${year}&session=${session}`,
+    )
+    console.log("\n\n[eventApi.getTeamShifts] response:", response.data)
+
+    if (response.ok && response.data) {
+      return response.data
+    }
+    return {
+      success: false,
+      error: (response.data as any)?.error || "Failed to retrieve team shifts",
+    } as ApiResponse<TeamShift[]>
   },
 }

--- a/app/services/hooks/useTeamShifts.ts
+++ b/app/services/hooks/useTeamShifts.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { eventApi } from "../api/eventApi"
+
+export const useTeamShifts = (day: number, month: number, year: number, session: string) => {
+  const {
+    data: teamShifts,
+    error,
+    isPending,
+    isFetching,
+  } = useQuery({
+    queryKey: ["team-shifts"],
+    queryFn: () => eventApi.getTeamShifts(day, month, year, session),
+    select: (result) => result.data,
+    refetchOnMount: false,
+  })
+
+  return { teamShifts, error, isPending, isFetching }
+}

--- a/backend/src/services/event.service.ts
+++ b/backend/src/services/event.service.ts
@@ -199,7 +199,7 @@ export class EventService {
     // Build the where clause for events
     // (1) Starts or ends within the month specified
     // (2) Has the specified session (AM/PM/AH)
-    const eventWhereClause: Prisma.EventWhereInput = {
+    const eventsForDayAndSession: Prisma.EventWhereInput = {
       AND: [
         {
           OR: [
@@ -231,7 +231,7 @@ export class EventService {
             id: true,
             name: true,
             events: {
-              where: eventWhereClause,
+              where: eventsForDayAndSession,
               select: {
                 id: true,
                 start_time: true,

--- a/backend/src/types/event.types.ts
+++ b/backend/src/types/event.types.ts
@@ -70,3 +70,121 @@ export type ShiftWithNumUsers = {
 export type OpenShift = ShiftWithNumUsers & {
   status: string
 }
+
+export type CampusWithLocationsAndEvents = Prisma.CampusGetPayload<{
+  select: {
+    id: true
+    name: true
+    locations: {
+      select: {
+        id: true
+        name: true
+        events: {
+          select: {
+            id: true
+            start_time: true
+            end_time: true
+            on_call: true
+            activity: {
+              select: {
+                id: true
+                name: true
+                activityGroup: {
+                  select: {
+                    id: true
+                    name: true
+                  }
+                }
+              }
+            }
+            eventAssignments: {
+              select: {
+                id: true
+                designation: {
+                  select: {
+                    id: true
+                    title: true
+                    description: true
+                  }
+                }
+                user: {
+                  select: {
+                    id: true
+                    first_name: true
+                    last_name: true
+                  }
+                }
+              }
+            }
+            eventSessions: {
+              select: {
+                id: true
+                session: true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}>
+
+export type ShiftWithLocation = Prisma.EventGetPayload<{
+  select: {
+    id: true
+    start_time: true
+    end_time: true
+    on_call: true
+    activity: {
+      select: {
+        id: true
+        name: true
+      }
+    }
+    location: {
+      select: {
+        id: true
+        name: true
+        campus: {
+          select: {
+            id: true
+            name: true
+          }
+        }
+      }
+    }
+    eventAssignments: {
+      select: {
+        id: true
+        user: {
+          select: {
+            id: true
+            first_name: true
+            last_name: true
+          }
+        }
+      }
+    }
+  }
+}>
+
+export type TeamShift = {
+  id: number
+  name: string
+  locations: Array<{
+    id: number
+    name: string
+    events: Array<{
+      id: number
+      start_time: Date
+      end_time: Date
+      on_call: boolean
+      activity: string | null
+      eventAssignments: Array<{
+        id: number
+        first_name: string
+        last_name: string
+      }>
+    }>
+  }>
+}


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-126)_

API for roster view -> team-roster

I'm undecided whether to keep or omit the current user's shifts here -> for now I have included them since I think it makes sense that you want to see your schedule w.r.t. everyone elses instead of flipping back and forth between MyRoster and TeamRoster

I tried to make the fields as minimal as possible to make this easy to work with

TO QA:
in postman: `http://localhost:3000/api/events/team-shifts?day=20&month=0&year=2025&Session=AM`
INTERSTINGLY WITH DATE FNS, MONTH IS ZERO-INDEXED!!!!!
so this is indexing for 2025 JANUARY 20th

Should see this event:

<img width="641" height="144" alt="image" src="https://github.com/user-attachments/assets/f52b2a38-c059-45ea-b66a-e9a57c09a955" />

with 3 users:
<img width="678" height="213" alt="image" src="https://github.com/user-attachments/assets/3f2ceb36-b9e0-4d40-ba4e-d01c7c903fc1" />



API endpoint return shape
```
{
    "success": true,
    "data": [
        {
            "id": 1,
            "name": "Main Campus",
            "locations": [
                {
                    "id": 4,
                    "name": "ICU Ward A",
                    "events": [
                        {
                            "id": 3,
                            "start_time": "2025-01-21T07:00:00.000Z",
                            "end_time": "2025-01-21T09:00:00.000Z",
                            "on_call": false,
                            "activity": {
                                "id": 4,
                                "name": "Morning Rounds"
                            },
                            "eventAssignments": [
                                {
                                    "user": {
                                        "id": 3,
                                        "first_name": "Michael",
                                        "last_name": "Williams"
                                    }
                                },
                                {
                                    "user": {
                                        "id": 10,
                                        "first_name": "Maria",
                                        "last_name": "Anderson"
                                    }
                                }
                            ]
                        }
                    ]
                },
```

Hook return type: (campus) -> list of locations -> list of events -> list of users
```javascript
const transformedData: {
    locations: {
        events: {
            id: number;
            start_time: Date;
            end_time: Date;
            on_call: boolean;
            activity: string | undefined;
            eventAssignments: {
                id: number;
                first_name: string;
                last_name: string;
            }[];
        }[];
        id: number;
        name: string;
    }[];
    id: number;
    name: string;
}[] | undefined
```


Note that there are multiple events in a location in a session (since each session spans quite a long duration)

<img width="399" height="685" alt="image" src="https://github.com/user-attachments/assets/65433d88-9a4d-4a6a-971c-8c2fc4c61568" />


---

<details open><summary><strong>Checklist</strong></summary>

- [ ] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
