### PR TITLE
WR-167 refactor(general): make related components match requirements for requests page

### DIFF
--- a/app/components/Lozenge.tsx
+++ b/app/components/Lozenge.tsx
@@ -12,9 +12,9 @@ interface LozengeProps {
     | "available"
     | "requested"
     | "urgent"
-    | "approved"
-    | "awaiting"
-    | "declined"
+    | "APPROVED"
+    | "AWAITING"
+    | "DECLINED"
     | "assigned"
     | "openShift"
   active?: boolean
@@ -65,19 +65,19 @@ export const LOZENGE_CONFIG: Record<LozengeProps["type"], LozengeConfig> = {
     bgColor: "red500",
     textColor: "red800",
   },
-  approved: {
+  APPROVED: {
     text: "Approved",
     bgColor: "green500",
     selectedBgColor: "green500",
     textColor: "green800",
   },
-  awaiting: {
+  AWAITING: {
     text: "Awaiting",
     bgColor: "yellow400",
     selectedBgColor: "yellow400",
     textColor: "yellow800",
   },
-  declined: {
+  DECLINED: {
     text: "Declined",
     bgColor: "red500",
     selectedBgColor: "red500",

--- a/app/components/RequestCard.tsx
+++ b/app/components/RequestCard.tsx
@@ -5,25 +5,53 @@ import { BodyText } from "./BodyText"
 import { Lozenge } from "./Lozenge"
 import { RequestTypeIcon } from "./RequestTypeIcon"
 
-type RequestType = "leave" | "swap" | "openShift"
+export type RequestType = "LEAVE" | "SWAP" | "ASSIGNMENT"
+export type RequestStatus = "APPROVED" | "AWAITING" | "DECLINED"
+export type LeaveType = "SICK" | "ANNUAL" | "COMPASSIONATE" | "PARENTAL" | "UNPAID"
 
 interface RequestCardProps {
   requestType: RequestType
-  date: Date
-  status: "approved" | "awaiting" | "declined"
+  startDate: Date
+  endDate: Date
+  status: RequestStatus
+  leaveType?: LeaveType
 }
 
 const REQUEST_MAP: Record<RequestType, string> = {
-  leave: "Leave",
-  swap: "Swap",
-  openShift: "OpenShift",
+  LEAVE: "Leave",
+  SWAP: "Swap",
+  ASSIGNMENT: "OpenShift",
+}
+
+const LEAVE_TYPE_MAP: Record<LeaveType, string> = {
+  SICK: "Sick",
+  ANNUAL: "Annual",
+  COMPASSIONATE: "Compassionate",
+  PARENTAL: "Parental",
+  UNPAID: "Unpaid",
 }
 
 export const RequestCard = (props: RequestCardProps) => {
-  const displayDate = format(props.date, "EEE, d MMM")
+  const startDateStr = format(props.startDate, "EEE, d MMM")
+  const endDateStr = format(props.endDate, "EEE, d MMM")
+  const startTimeStr = format(props.startDate, "HH:mm")
+  const endTimeStr = format(props.endDate, "HH:mm")
+  const isOvernightShift = startTimeStr > endTimeStr
+
+  let displayDate: string
+  let description: string
+
+  if (props.requestType === "LEAVE") {
+    displayDate = `${startDateStr} - ${endDateStr}`
+    description = props.leaveType ? `${LEAVE_TYPE_MAP[props.leaveType]} Leave` : ""
+  } else {
+    displayDate = isOvernightShift ? `Starts ${startDateStr}` : `On ${startDateStr}`
+    description = `${startTimeStr} - ${endTimeStr}`
+  }
+
   return (
     <Card
-      width={350}
+      width="90%"
       height={104}
       backgroundColor="$white200"
       justifyContent="center"
@@ -45,15 +73,16 @@ export const RequestCard = (props: RequestCardProps) => {
               paddingBlock="$2"
               paddingInline="$3"
               borderRadius="$radius.8"
+              style={$requestTitleStyle}
             >
               {REQUEST_MAP[props.requestType]} Request
             </BodyText>
             <YStack gap="$1">
               <BodyText variant="body3" marginInlineStart="$2">
-                On {displayDate}
+                {displayDate}
               </BodyText>
               <BodyText variant="body3" marginInlineStart="$2">
-                Description
+                {description}
               </BodyText>
             </YStack>
           </YStack>
@@ -64,4 +93,10 @@ export const RequestCard = (props: RequestCardProps) => {
       </XStack>
     </Card>
   )
+}
+
+const $requestTitleStyle = {
+  maxWidth: 140,
+  alignSelf: "flex-start",
+  flexShrink: 0,
 }

--- a/app/components/RequestTypeIcon.tsx
+++ b/app/components/RequestTypeIcon.tsx
@@ -3,16 +3,16 @@ import { Group, useTheme } from "tamagui"
 import { Icon, IconTypes } from "./Icon"
 
 export const REQUEST_TYPE_ICON_MAP: Record<string, IconTypes> = {
-  leave: "leave",
-  swap: "swap",
-  openShift: "openShift",
+  LEAVE: "leave",
+  SWAP: "swap",
+  ASSIGNMENT: "openShift",
   default: "meh",
 }
 
 export const REQUEST_TYPE_COLOR_MAP: Record<string, string> = {
-  leave: "secondary400",
-  swap: "yellow400",
-  openShift: "green500",
+  LEAVE: "secondary400",
+  SWAP: "yellow400",
+  ASSIGNMENT: "green500",
   default: "mono300",
 }
 


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-167)_

Commits:
1. Components need to have matching params with what is provided by the backend. E.g LEAVE is provided by the backend but the component accepts Leave 
2. Allows request cards to support multiple days and passed in leave types as an optional parameter so that it can be rendered.

Before:
<img width="380" height="690" alt="image" src="https://github.com/user-attachments/assets/019de874-c337-4b34-a68c-1eeea2af44ff" />


After:
<img width="377" height="644" alt="image" src="https://github.com/user-attachments/assets/bf2c2ad5-b282-4941-b40d-5e35694cfde7" />


What the cards look like on ios and android:
<img width="677" height="523" alt="image" src="https://github.com/user-attachments/assets/40b03cd1-c79e-4420-a0ea-01cb9191948d" />


Note:  I've updated the changelogs for all components touched on confluence




---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
