### PR TITLE
WR-125 feat(open-shifts): build fetch api for open shifts

### DIFF
--- a/app/screens/RosterScreen/OpenShiftsScreen.tsx
+++ b/app/screens/RosterScreen/OpenShiftsScreen.tsx
@@ -1,9 +1,14 @@
 import { View } from "react-native"
 import { NativeStackScreenProps } from "@react-navigation/native-stack"
+import { format } from "date-fns"
 
+import { ShiftWithNumUsers } from "backend/src/types/event.types"
+
+import { BodyText } from "@/components/BodyText"
 import { Screen } from "@/components/Screen"
 import { Text } from "@/components/Text"
 import type { RosterStackParamList } from "@/navigators/DashboardNavigator"
+import { useOpenShifts } from "@/services/hooks/useOpenShifts"
 import { useAppTheme } from "@/theme/context"
 import { $styles } from "@/theme/styles"
 
@@ -11,6 +16,7 @@ type Props = NativeStackScreenProps<RosterStackParamList, "OpenShifts">
 
 export function OpenShiftsScreen(_props: Props) {
   const { themed } = useAppTheme()
+  const { openShifts } = useOpenShifts()
 
   return (
     <Screen preset="scroll" contentContainerStyle={$styles.container}>
@@ -25,6 +31,22 @@ export function OpenShiftsScreen(_props: Props) {
           and actions (request, apply, etc.) here.
         </Text>
       </View>
+
+      {openShifts && (
+        <View>
+          {openShifts.map((event: ShiftWithNumUsers) => (
+            <View key={event.id}>
+              <BodyText variant="body4">
+                {event.id}: {event.activity?.name} @ {event.location?.name} on{" "}
+                {format(event.start_time!, "dd MMM yyyy 'at' h:mma")} to{" "}
+                {format(event.end_time!, "h:mma")} with {event.numUsers} users
+              </BodyText>
+            </View>
+          ))}
+
+          {openShifts.length === 0 && <BodyText variant="body4">No events found</BodyText>}
+        </View>
+      )}
     </Screen>
   )
 }

--- a/app/services/api/eventApi.ts
+++ b/app/services/api/eventApi.ts
@@ -16,6 +16,19 @@ export const eventApi = {
     } as ApiResponse<ShiftWithNumUsers[]>
   },
 
+  getOpenShifts: async () => {
+    const response = await api.get<ApiResponse<ShiftWithNumUsers[]>>("/events/open-shifts")
+    console.log("\n\n[eventApi.getOpenShifts] response:", response.data)
+
+    if (response.ok && response.data) {
+      return response.data
+    }
+    return {
+      success: false,
+      error: (response.data as any)?.error || "Failed to retrieve events",
+    } as ApiResponse<ShiftWithNumUsers[]>
+  },
+
   getShiftById: async (shiftId: number) => {
     const response = await api.get<ApiResponse<ShiftWithNumUsers>>(`/events/${shiftId}`)
     console.log("\n\n[eventApi.getShiftById] response:", response.data)

--- a/app/services/hooks/useOpenShifts.ts
+++ b/app/services/hooks/useOpenShifts.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { eventApi } from "../api/eventApi"
+
+export const useOpenShifts = () => {
+  const {
+    data: openShifts,
+    error,
+    isPending,
+    isFetching,
+  } = useQuery({
+    queryKey: ["open-shifts"],
+    queryFn: eventApi.getOpenShifts,
+    select: (result) => result.data,
+    refetchOnMount: false,
+  })
+
+  return { openShifts, error, isPending, isFetching }
+}

--- a/backend/src/routes/event.routes.ts
+++ b/backend/src/routes/event.routes.ts
@@ -43,6 +43,30 @@ router.get("/my-shifts", authenticate, async (req, res) => {
   return
 })
 
+router.get("/open-shifts", authenticate, async (req, res) => {
+  try {
+    const service = new EventService(req.app.locals.prisma)
+
+    // Ensure user is authenticated
+    if (!req.userId) {
+      return res.status(HttpStatus.UNAUTHORIZED).json({
+        success: false,
+        error: "User not authenticated",
+      })
+    }
+
+    const openShifts = await service.getOpenShifts(req.userId)
+
+    res.json({
+      success: true,
+      data: openShifts,
+    })
+  } catch (error: any) {
+    res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({ error: error.message })
+  }
+  return
+})
+
 router.get("/:shiftId", authenticate, async (req, res) => {
   try {
     const service = new EventService(req.app.locals.prisma)


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-125)_

need to clarify with client, but for our purposes right, I am treating an open shift as a **shift with 0 users assigned to it**

obv some real world flaws with this assumption but we can roll with this for now considering this is a FE refresh

Response shapes are identical to MyRoster (myShifts api + hook), just with an additional where clause of no users (plus same hospital ID) -> this is so that the FE components that handle shifts can expect the same type!!

API Response:

```
{
    "success": true,
    "data": [
        {
            "id": 18,
            "start_time": "2025-01-29T08:00:00.000Z",
            "end_time": "2025-01-29T14:00:00.000Z",
            "on_call": true,
            "activity": {
                "id": 2,
                "name": "Cardiac Surgery",
                "group_id": 1,
                "location_id": 2
            },
            "location": {
                "id": 2,
                "name": "Operating Room 2",
                "campus_id": 1
            },
            "eventAssignments": [],
            "numUsers": 0
        },
        {
            "id": 19,
            "start_time": "2025-01-30T10:00:00.000Z",
            "end_time": "2025-01-30T12:00:00.000Z",
            "on_call": false,
            "activity": {
                "id": 19,
                "name": "X-Ray Services",
                "group_id": 6,
                "location_id": 1
            },
            "location": {
                "id": 1,
                "name": "Operating Room 1",
                "campus_id": 1
            },
            "eventAssignments": [],
            "numUsers": 0
        },
```

hook response

```
[
  {
    "id": 18,
    "start_time": "2025-01-29T08:00:00.000Z",
    "end_time": "2025-01-29T14:00:00.000Z",
    "on_call": true,
    "activity": {
      "id": 2,
      "name": "Cardiac Surgery",
      "group_id": 1,
      "location_id": 2
    },
    "location": {
      "id": 2,
      "name": "Operating Room 2",
      "campus_id": 1
    },
    "eventAssignments": [],
    "numUsers": 0
  },
  {
    "id": 19,
    "start_time": "2025-01-30T10:00:00.000Z",
    "end_time": "2025-01-30T12:00:00.000Z",
    "on_call": false,
    "activity": {
      "id": 19,
      "name": "X-Ray Services",
      "group_id": 6,
      "location_id": 1
    },
    "location": {
      "id": 1,
      "name": "Operating Room 1",
      "campus_id": 1
    },
    "eventAssignments": [],
    "numUsers": 0
  },
]
```


<img width="405" height="835" alt="image" src="https://github.com/user-attachments/assets/e7cf3981-a234-49d6-8095-eab0a61cf1e3" />



---

<details open><summary><strong>Checklist</strong></summary>

- [ ] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
