### PR TITLE
WR-159 feat(general): :sparkles: create shift card component

### DIFF
--- a/app/components/ShiftCard.tsx
+++ b/app/components/ShiftCard.tsx
@@ -1,0 +1,115 @@
+import { format } from "date-fns"
+import { Card, useTheme, XStack, YStack } from "tamagui"
+
+import { ShiftWithNumUsers, OpenShift } from "backend/src/types/event.types"
+
+import { BodyText } from "./BodyText"
+import { StyledIcon } from "./common/StyledIcon"
+import { Icon, IconTypes } from "./Icon"
+import { type Session, SESSION_LABEL_BG_COLOUR_MAP } from "./ShiftDetailsSubheader"
+
+export const SHIFT_SESSION_ICON_MAP: Record<Session, string> = {
+  AM: "am",
+  PM: "pm",
+  AH: "afterHours",
+}
+
+interface ShiftCardProps {
+  shift: ShiftWithNumUsers | OpenShift
+  clashes?: boolean
+}
+
+const ShiftCard = ({ shift, clashes }: ShiftCardProps) => {
+  const theme = useTheme()
+
+  const isOpenShift = "status" in shift
+  const firstSession = shift.eventSessions[0] as Session
+
+  // Configuration map for different shift states
+  const getShiftConfig = () => {
+    if (clashes) {
+      return {
+        iconSubText: firstSession,
+        iconBgColor: theme[SESSION_LABEL_BG_COLOUR_MAP[firstSession]]?.val,
+        cardBgColor: theme.white200?.val,
+        icon: SHIFT_SESSION_ICON_MAP[firstSession] as IconTypes,
+      }
+    }
+
+    if (isOpenShift && shift.status === "REQUESTED") {
+      return {
+        iconSubText: "Pending",
+        iconBgColor: theme.yellow300?.val,
+        cardBgColor: theme.yellow100?.val,
+        icon: SHIFT_SESSION_ICON_MAP[firstSession] as IconTypes,
+      }
+    }
+
+    if (isOpenShift) {
+      return {
+        iconSubText: "Open",
+        iconBgColor: theme.green500?.val,
+        cardBgColor: theme.green200?.val,
+        icon: SHIFT_SESSION_ICON_MAP[firstSession] as IconTypes,
+      }
+    }
+
+    return {
+      iconSubText: firstSession,
+      iconBgColor: theme[SESSION_LABEL_BG_COLOUR_MAP[firstSession]]?.val,
+      cardBgColor: theme.white200?.val,
+      icon: SHIFT_SESSION_ICON_MAP[firstSession] as IconTypes,
+    }
+  }
+
+  const config = getShiftConfig()
+
+  return (
+    <Card
+      backgroundColor={config.cardBgColor}
+      height={80}
+      width={"100%"}
+      elevation={4}
+      shadowColor="$mono900"
+      shadowOffset={{ width: 0, height: 4 }}
+      shadowOpacity={0.25}
+      shadowRadius={4}
+      borderRadius="$radius.4"
+    >
+      <XStack alignItems="center" gap="$3" height={"100%"} padding="$2">
+        <YStack
+          height={"100%"}
+          aspectRatio={1}
+          backgroundColor={config.iconBgColor}
+          alignItems="center"
+          justifyContent="center"
+          borderRadius="$radius.4"
+          gap="$2"
+        >
+          {config.icon && <Icon icon={config.icon} size={24} />}
+          <BodyText variant="body4">{config.iconSubText}</BodyText>
+        </YStack>
+        <YStack gap="$1.5">
+          <XStack alignItems="center" gap="$2">
+            <StyledIcon icon="clock" />
+            <BodyText variant="body2">
+              {format(shift.start_time, "HH:mm")} - {format(shift.end_time, "HH:mm")}
+            </BodyText>
+          </XStack>
+          <XStack alignItems="center" gap="$2">
+            <StyledIcon icon="building" />
+            <BodyText variant="body2">{shift.location}</BodyText>
+          </XStack>
+          {shift.numUsers > 0 && (
+            <XStack gap="$2">
+              <StyledIcon icon="user2" />
+              <BodyText variant="body2">Working with {shift.numUsers} others</BodyText>
+            </XStack>
+          )}
+        </YStack>
+      </XStack>
+    </Card>
+  )
+}
+
+export { ShiftCard }

--- a/app/components/ShiftDetailsSubheader.tsx
+++ b/app/components/ShiftDetailsSubheader.tsx
@@ -4,7 +4,7 @@ import { useTheme, XStack } from "tamagui"
 import { BodyText } from "./BodyText"
 import { Icon } from "./Icon"
 
-const SESSION_LABEL_BG_COLOUR_MAP: Record<Session, string> = {
+export const SESSION_LABEL_BG_COLOUR_MAP: Record<Session, string> = {
   AM: "yellow300",
   PM: "red300",
   AH: "secondary300",


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-159)_

Shift card for MyRoster and Open Shift page

Waiting on fully implementing the `clashes` prop as that will be a whole different full stack beast
Since Session isn't (yet) mandatory on an Event, I just have some precautionary default values (gray, no icon) for when no Session is provided/in the Event payload

Also made the design decision to omit the designation field because: Users one-to-one with a designation -> all shifts the user ever sees in these two views will be (open) shifts for their designation -> redundant info

To QA:
can go to any screen and pull data using our hooks

```javascript
const { openShifts } = useOpenShifts()
const { myShifts } = useMyShifts()
```

I setup the DB so the first few shifts show all the session options
```javascript
      {myShifts && openShifts && (
        <>
          <ShiftCard shift={openShifts[0]} />
          <ShiftCard shift={openShifts[1]} />
          <ShiftCard shift={myShifts[0]} />
          <ShiftCard shift={myShifts[2]} />
          <ShiftCard shift={myShifts[3]} />
          <ShiftCard shift={myShifts[4]} />
        </>
      )}
```

<img width="334" height="446" alt="image" src="https://github.com/user-attachments/assets/47a3d3cd-e657-4e4b-9f2b-2de35cbe5815" />








---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
