### PR TITLE
WR-142 feat(my-roster): Create ShiftDetailsSubheader component

### DIFF
--- a/app/components/ShiftDetailsSubheader.tsx
+++ b/app/components/ShiftDetailsSubheader.tsx
@@ -1,0 +1,67 @@
+import { differenceInHours, format } from "date-fns"
+import { useTheme, XStack } from "tamagui"
+
+import { BodyText } from "./BodyText"
+import { Icon } from "./Icon"
+
+const SESSION_COLOUR_MAP: Record<string, string> = {
+  AM: "yellow300",
+  PM: "red300",
+  AH: "secondary300",
+}
+
+interface ShiftDetailsSubheaderProps {
+  start: Date
+  end: Date
+  session: string
+}
+
+export const ShiftDetailsSubheader = ({ start, end, session }: ShiftDetailsSubheaderProps) => {
+  const theme = useTheme()
+
+  const displayDate = format(start, "EEE, d MMM")
+  const timeRange = `${format(start, "HH:mm")} - ${format(end, "HH:mm")}`
+  const duration = differenceInHours(end, start)
+
+  const dateIcon = session === "AM" || session === "PM" ? "sun" : "moon"
+  const bgColor = theme[SESSION_COLOUR_MAP[session]]?.val ?? theme.white100.val
+
+  return (
+    <XStack backgroundColor="$white500" width="100%" justifyContent="space-between" padding={16}>
+      <XStack
+        backgroundColor="$white100"
+        padding={8}
+        alignItems="center"
+        justifyContent="center"
+        borderRadius="$3"
+        minWidth={110}
+        gap="$2"
+      >
+        <Icon icon={dateIcon} size={16} />
+        <BodyText variant="body3">{displayDate}</BodyText>
+      </XStack>
+      <XStack
+        backgroundColor={bgColor}
+        padding={8}
+        alignItems="center"
+        justifyContent="center"
+        borderRadius="$3"
+        minWidth={100}
+      >
+        <BodyText variant="body3">{timeRange}</BodyText>
+      </XStack>
+      <XStack
+        backgroundColor="$white100"
+        padding={8}
+        alignItems="center"
+        justifyContent="center"
+        borderRadius="$3"
+        minWidth={110}
+        gap="$2"
+      >
+        <Icon icon="clock" size={16} />
+        <BodyText variant="body3">{duration} hours</BodyText>
+      </XStack>
+    </XStack>
+  )
+}

--- a/app/components/ShiftDetailsSubheader.tsx
+++ b/app/components/ShiftDetailsSubheader.tsx
@@ -4,27 +4,33 @@ import { useTheme, XStack } from "tamagui"
 import { BodyText } from "./BodyText"
 import { Icon } from "./Icon"
 
-const SESSION_COLOUR_MAP: Record<string, string> = {
+const SESSION_LABEL_BG_COLOUR_MAP: Record<Session, string> = {
   AM: "yellow300",
   PM: "red300",
   AH: "secondary300",
 }
 
+export type Session = "AM" | "PM" | "AH"
+
 interface ShiftDetailsSubheaderProps {
-  start: Date
-  end: Date
-  session: string
+  startDate: Date
+  endDate: Date
+  session: Session
 }
 
-export const ShiftDetailsSubheader = ({ start, end, session }: ShiftDetailsSubheaderProps) => {
+export const ShiftDetailsSubheader = ({
+  startDate,
+  endDate,
+  session,
+}: ShiftDetailsSubheaderProps) => {
   const theme = useTheme()
 
-  const displayDate = format(start, "EEE, d MMM")
-  const timeRange = `${format(start, "HH:mm")} - ${format(end, "HH:mm")}`
-  const duration = differenceInHours(end, start)
+  const displayDate = format(startDate, "EEE, d MMM")
+  const timeRange = `${format(startDate, "HH:mm")} - ${format(endDate, "HH:mm")}`
+  const duration = differenceInHours(endDate, startDate)
 
   const dateIcon = session === "AM" || session === "PM" ? "sun" : "moon"
-  const bgColor = theme[SESSION_COLOUR_MAP[session]]?.val ?? theme.white100.val
+  const bgColor = theme[SESSION_LABEL_BG_COLOUR_MAP[session]]?.val ?? theme.white100.val
 
   return (
     <XStack backgroundColor="$white500" width="100%" justifyContent="space-between" padding={16}>


### PR DESCRIPTION

### Changes:
- Created a `ShiftDetailsSubheader` component that takes in `start`, `end` and `session`. 
- Note that the `backgroundColor` on the duration will default to "$white100" when there is no `EventSession` on the `Event` object (may need to consider backfilling).

iOS:
<img width="361" height="274" alt="Screenshot 2025-10-05 at 12 49 43 am" src="https://github.com/user-attachments/assets/334a76f3-b669-48bc-bfaa-bb5cc13e2830" />

Android:
<img width="351" height="267" alt="Screenshot 2025-10-05 at 12 52 08 am" src="https://github.com/user-attachments/assets/916be269-69ae-4e51-9723-871e377e7b84" />


---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
