### PR TITLE
WR-176 feat(my-roster): Replace calendar items with customer component

### DIFF
--- a/app/components/RosterCalendar.tsx
+++ b/app/components/RosterCalendar.tsx
@@ -5,6 +5,7 @@ import { View, Text, useTheme } from "tamagui"
 
 import { ShiftWithNumUsers } from "backend/src/types/event.types"
 
+import { BodyText } from "./BodyText"
 import { CustomMarking, DayEvent, DayPill } from "./DayPill"
 import { ShiftCard } from "./ShiftCard"
 
@@ -107,8 +108,28 @@ export const RosterCalendar = ({ events }: RosterCalendarProps) => {
         sections={sections}
         keyExtractor={(item) => item.id}
         dayFormatter={(day) => format(parseISO(day), "EEE, d MMM")}
+        renderSectionHeader={(section) => {
+          const dateKey = section as unknown as string
+          const displayDate = format(dateKey, "yyyy-MM-dd")
+          const isToday = displayDate === format(new Date(), "yyyy-MM-dd")
+
+          return (
+            <View
+              backgroundColor={isToday ? "$secondary500" : "$white400"}
+              height={40}
+              justifyContent="center"
+              paddingInlineStart={30}
+            >
+              <BodyText variant="body2" color={isToday ? "$white100" : "$mono900"}>
+                {isToday
+                  ? `TODAY - ${format(parseISO(dateKey), "EEE, d MMM").toUpperCase()}`
+                  : format(parseISO(dateKey), "EEE, d MMM").toUpperCase()}
+              </BodyText>
+            </View>
+          )
+        }}
         renderItem={({ item }) => (
-          <View paddingHorizontal="$3" paddingVertical="$2">
+          <View paddingHorizontal="$3" paddingVertical={8} backgroundColor="$white100">
             <ShiftCard shift={item.shift} />
           </View>
         )}

--- a/app/components/RosterCalendar.tsx
+++ b/app/components/RosterCalendar.tsx
@@ -6,6 +6,7 @@ import { View, Text, useTheme } from "tamagui"
 import { ShiftWithNumUsers } from "backend/src/types/event.types"
 
 import { CustomMarking, DayEvent, DayPill } from "./DayPill"
+import { ShiftCard } from "./ShiftCard"
 
 interface RosterCalendarProps {
   events: ShiftWithNumUsers[]
@@ -13,11 +14,7 @@ interface RosterCalendarProps {
 
 type AgendaItem = {
   id: string
-  name: string
-  timeRange: string
-  location: string
-  start: Date
-  numUsers: number
+  shift: ShiftWithNumUsers
 }
 
 type AgendaSection = {
@@ -35,17 +32,12 @@ function buildAgendaSections(shifts: ShiftWithNumUsers[]) {
 
   for (const shift of shifts) {
     const start = shift.start_time
-    const end = shift.end_time
 
     const dateKey = format(start, "yyyy-MM-dd")
 
     const item: AgendaItem = {
       id: String(shift.id),
-      name: shift.activity ?? "Shift",
-      timeRange: `${format(start, "h:mm a")} – ${format(end, "h:mm a")}`,
-      location: shift.location,
-      start,
-      numUsers: shift.numUsers,
+      shift: shift,
     }
 
     const lastSection = sections[sections.length - 1]
@@ -117,12 +109,7 @@ export const RosterCalendar = ({ events }: RosterCalendarProps) => {
         dayFormatter={(day) => format(parseISO(day), "EEE, d MMM")}
         renderItem={({ item }) => (
           <View paddingHorizontal="$3" paddingVertical="$2">
-            <Text fontWeight="600">{item.timeRange}</Text>
-            <Text>
-              {item.name}
-              {item.location ? ` · ${item.location}` : ""}
-            </Text>
-            <Text>{item.numUsers - 1} others working</Text>
+            <ShiftCard shift={item.shift} />
           </View>
         )}
         ListEmptyComponent={

--- a/app/screens/RosterScreen/MyRosterScreen.tsx
+++ b/app/screens/RosterScreen/MyRosterScreen.tsx
@@ -11,27 +11,6 @@ export function MyRosterScreen(_props: Props) {
   const tomorrow = new Date()
   tomorrow.setDate(today.getDate() + 1)
 
-  // const accordionSections = [
-  //   {
-  //     sectionText: format(today, "EEE, d MMM"),
-  //     isCurrent: true,
-  //     children: (
-  //       <YStack padding={16} backgroundColor={themes.white100.val}>
-  //         <BodyText>Today&apos;s Shifts Here</BodyText>
-  //       </YStack>
-  //     ),
-  //   },
-  //   {
-  //     sectionText: format(tomorrow, "EEE, d MMM"),
-  //     isCurrent: false,
-  //     children: (
-  //       <YStack padding={16} backgroundColor={themes.white100.val}>
-  //         <BodyText>Tomorrow&apos;s Shifts Here</BodyText>
-  //       </YStack>
-  //     ),
-  //   },
-  // ]
-
   const { myShifts } = useMyShifts()
 
   return <RosterCalendar events={myShifts ?? []} />


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-176)_

### Changes: 
- Replace the`renderItem` JSX with the ShiftCard component in `RosterCalendar`
- Added styling to the section headers.

Adjusted:
<img width="351" height="154" alt="Screenshot 2025-10-08 at 12 56 55 pm" src="https://github.com/user-attachments/assets/3d6d3758-bbe4-4858-8ac5-fa6618d9c44a" />
<img width="358" height="225" alt="Screenshot 2025-10-08 at 12 57 47 pm" src="https://github.com/user-attachments/assets/23d7f36e-360a-4073-9903-11a7e540f14c" />


iOS:

<img width="362" height="651" alt="Screenshot 2025-10-08 at 12 33 00 am" src="https://github.com/user-attachments/assets/0bc9514f-a6f9-4c0e-97d5-53c6103da1ce" />

Android:

<img width="352" height="797" alt="Screenshot 2025-10-08 at 12 35 16 am" src="https://github.com/user-attachments/assets/9ea3c8f6-90b5-4af4-9051-50b515462447" />




---

<details open><summary><strong>Checklist</strong></summary>

- [x] My PR title is prefixed with WR-XX
- [x] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
