### PR TITLE
WR-247 feat(my-roster): :sparkles: add search bar to swapshiftscreen

### DIFF
--- a/app/components/SearchHeader.tsx
+++ b/app/components/SearchHeader.tsx
@@ -1,8 +1,7 @@
-import { Pressable, ViewStyle } from "react-native"
-import { Controller, useForm } from "react-hook-form"
+import { useState, memo } from "react"
+import { ViewStyle } from "react-native"
 import { Input, XStack, useTheme } from "tamagui"
 
-import { Icon } from "@/components/Icon"
 import { tamaguiConfig } from "@/tamagui.config"
 
 interface SearchHeaderProps {
@@ -10,14 +9,14 @@ interface SearchHeaderProps {
   style?: ViewStyle
 }
 
-export function SearchHeader({ onSearch, style }: SearchHeaderProps) {
+const SearchHeaderComponent = ({ onSearch, style }: SearchHeaderProps) => {
   const theme = useTheme()
+  const [searchValue, setSearchValue] = useState("")
 
-  const searchInput = useForm<{ query: string }>({
-    defaultValues: {
-      query: "",
-    },
-  })
+  const handleTextChange = (text: string) => {
+    setSearchValue(text)
+    onSearch(text)
+  }
 
   return (
     <XStack
@@ -29,41 +28,28 @@ export function SearchHeader({ onSearch, style }: SearchHeaderProps) {
       position="relative"
       style={style}
     >
-      <Pressable onPress={() => {}}>
-        <Icon icon="sliders" size={24} color={theme.mono900.val} />
-      </Pressable>
-      <Controller
-        control={searchInput.control}
-        name="query"
-        render={({ field: { onChange, onBlur, value } }) => (
-          <Input
-            unstyled
-            flex={1}
-            marginHorizontal="$2"
-            paddingVertical="$2"
-            paddingHorizontal="$3"
-            borderRadius="$7"
-            borderWidth={1}
-            borderColor={tamaguiConfig.tokens.color.white900}
-            backgroundColor={tamaguiConfig.tokens.color.white900}
-            placeholder="Search name, designation or location"
-            placeholderTextColor={theme.mono900.val}
-            fontSize={16}
-            value={value}
-            onChangeText={(text) => {
-              onChange(text)
-              onSearch(text)
-            }}
-            onBlur={() => {
-              onBlur()
-            }}
-            returnKeyType="search"
-            onSubmitEditing={() => {
-              onSearch(value)
-            }}
-          />
-        )}
+      <Input
+        unstyled
+        flex={1}
+        marginHorizontal="$2"
+        paddingVertical="$2"
+        paddingHorizontal="$3"
+        borderRadius="$7"
+        borderWidth={1}
+        borderColor={tamaguiConfig.tokens.color.white900}
+        backgroundColor={tamaguiConfig.tokens.color.white900}
+        placeholder="Search name, designation or location"
+        placeholderTextColor={theme.mono900.val}
+        fontSize={14}
+        value={searchValue}
+        onChangeText={handleTextChange}
+        returnKeyType="search"
+        onSubmitEditing={() => {
+          onSearch(searchValue)
+        }}
       />
     </XStack>
   )
 }
+
+export const SearchHeader = memo(SearchHeaderComponent)

--- a/app/screens/DashboardTeamsScreen.tsx
+++ b/app/screens/DashboardTeamsScreen.tsx
@@ -1,4 +1,4 @@
-import { FC, useState, useMemo } from "react"
+import { FC, useState, useMemo, useCallback } from "react"
 import { XStack, YStack, Spinner, ScrollView } from "tamagui"
 
 import { BodyText } from "@/components/BodyText"
@@ -30,9 +30,9 @@ export const DashboardTeamsScreen: FC<DashboardTabScreenProps<"DashboardTeams">>
       })
     }, [teamMemberData, searchQuery])
 
-    const handleSearch = (query: string) => {
+    const handleSearch = useCallback((query: string) => {
       setSearchQuery(query)
-    }
+    }, [])
 
     return (
       <Screen>


### PR DESCRIPTION
_[JIRA Ticket](https://comp30022weroster2025s2.atlassian.net/browse/WR-247)_

Search now available when swapping shifts! Small refactor in SearchHeader so that re-renders don't affect the current input, and also extracted the SwapShiftSection function so that re-rendering the screen doesn't remount the component.

ALSO deleted the filter button since we're not doing that anymore according to Aaron :D

https://github.com/user-attachments/assets/b4ccaf12-57c2-4050-bf27-b18894c219c2

https://github.com/user-attachments/assets/d3419754-2811-4300-8ff4-e78fdac645e1

---

<details open><summary><strong>Checklist</strong></summary>

- [ ] My PR title is prefixed with WR-XX
- [ ] If I made a frontend change, I have included videos/screenshots of the changes on both iOS and Android
</details>
